### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.8] - 2016-06-28
+### Added
+- "labelFont" option to createToolbar
+- "labelText" option to createToolbar "list" attribute. Allows the mix of Material icon font and text/word
+font.  Label a button as "View" the button contain the text "View"
+
 ## [0.1.8] - 2016-06-27
 ### Added
 - "easing" option to createDialog and use easing library built-in corona sdk.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Please read Lua code to find all parameters and see example in the repo call men
 - `createTextBox` - Create a text box with label above (for now) and includes "scrollView" support. See fun.lua for an example.
 - `createTextField` - Create a text field with label above (for now) and includes "scrollView" support.  See fun.lua for an example.
 - `createToggleSwitch` - Create a toggle switch. See menu.lua for an example.
-- `createToolbar` - Create a horizontal toolbar with icon buttons using the material design icon font. You can override the font.
+- `createToolbar` - Create a horizontal toolbar with icon buttons using the material design icon font. Each toolbar button supports either material design icon or use "labelText" to use a normal text/word instead of icon. Mixing both on the same toolbar is supported.  To specify alternate font use "labelFont" attribute.  See menu.lua example (1 option is commented out, uncomment to see it work).
 
 Helper Methods
 -------------

--- a/materialui/mui.lua
+++ b/materialui/mui.lua
@@ -1286,14 +1286,12 @@ function M.createToolbarButton( options )
         textColor = options.textColor
     end
 
-    local labelFont = native.systemFont
-    if options.labelFont ~= nil then
-        labelFont = options.labelFont
+    if options.labelFont ~= nil and options.labelText ~= nil then
+        font = options.labelFont
     end
 
-    local label = "???"
-    if options.label ~= nil then
-        label = options.label
+    if options.labelText ~= nil then
+        options.text = options.labelText
     end
 
     local labelColor = { 0, 0, 0 }
@@ -1464,7 +1462,9 @@ function M.createToolbar( options )
                 y = y,
                 isChecked = v.isChecked,
                 font = "MaterialIcons-Regular.ttf",
+                labelText = v.labelText,
                 labelFont = options.labelFont,
+                labelFontSize = options.labelFontSize,
                 textColor = options.labelColor,
                 textColorOff = options.labelColorOff,
                 textAlign = "center",

--- a/menu.lua
+++ b/menu.lua
@@ -200,7 +200,8 @@ function scene:create( event )
             { key = "Home", value = "1", icon="home", isChecked = true},
             { key = "Newsroom", value = "2", icon="new_releases", isChecked = false },
             { key = "Location", value = "3", icon="location_searching", isChecked = false },
-            { key = "To-do List", value = "4", icon="view_list", isChecked = false }
+            { key = "To-do List", value = "4", icon="view_list", isChecked = false },
+            -- { key = "Viewer", value = "4", labelText="View", isChecked = false } -- uncomment to see View as text
         }
     })
 


### PR DESCRIPTION
Added:
- "labelFont" option to createToolbar
- "labelText" option to createToolbar "list" attribute. Allows the mix of Material icon font and text/word
  font.  Label a button as "View" the button contain the text "View"  Mixing icon font and text/word font on same toolbar is allowed.
