### PR TITLE
Fixed a number of toolbar issues and added text beneath icon support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.9] - 2016-06-29
+### Added
+- "labelFont" option to createToolbar
+- "labelText" option to createToolbar "list" of buttons. Allows a button to contain: Icon only, Text only or Icon with Text beneath.
+
+### Change
+- "x" option to createToolbar now works as expected. Set to 0 if wanting to use a toolbar that is 100% width of display.
+- "width" option to createToolbar now works as expected. If width is omitted the toolbar width defaults to 100% or display.contentWidth
+- "touchpoint" option to createToolbar now works as expected.
+- "callBack" for createToolbar works as expected. It will do the animation and then call the user-defined callBack.
+
 ## [0.1.8] - 2016-06-28
 ### Added
 - "labelFont" option to createToolbar

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Please read Lua code to find all parameters and see example in the repo call men
 - `createTextField` - Create a text field with label above (for now) and includes "scrollView" support.  See fun.lua for an example.
 - `createToggleSwitch` - Create a toggle switch. See menu.lua for an example.
 - `createToolbar` - Create a horizontal toolbar with icon buttons using the material design icon font. Each toolbar button supports either material design icon or use "labelText" to use a normal text/word instead of icon. Mixing both on the same toolbar is supported.  To specify alternate font use "labelFont" attribute.  See menu.lua example (1 option is commented out, uncomment to see it work).
+Usage of Icon and Text together is supported (Icon on top and text beneath).
 
 Helper Methods
 -------------

--- a/menu.lua
+++ b/menu.lua
@@ -184,7 +184,7 @@ function scene:create( event )
     local buttonHeight = mui.getScaleVal(70)
     mui.createToolbar({
         name = "toolbar_demo",
-        width = mui.getScaleVal(20), -- default to 100% for now
+        --width = mui.getScaleVal(500), -- defaults to display.contentWidth
         height = mui.getScaleVal(20),
         buttonHeight = buttonHeight,
         x = 0,
@@ -194,13 +194,13 @@ function scene:create( event )
         color = { 0.67, 0, 1 },
         labelColor = { 1, 1, 1 },
         labelColorOff = { 0.41, 0.03, 0.49 },
-        callBack = mui.actionForToolbar,
+        callBack = mui.actionForToolbarDemo,
         sliderColor = { 1, 1, 1 },
         list = {
-            { key = "Home", value = "1", icon="home", isChecked = true},
-            { key = "Newsroom", value = "2", icon="new_releases", isChecked = false },
-            { key = "Location", value = "3", icon="location_searching", isChecked = false },
-            { key = "To-do List", value = "4", icon="view_list", isChecked = false },
+            { key = "Home", value = "1", icon="home", labelText="Home", isChecked = true},
+            { key = "Newsroom", value = "2", icon="new_releases", labelText="Newsroom", isChecked = false },
+            { key = "Location", value = "3", icon="location_searching", labelText="Location", isChecked = false },
+            { key = "To-do", value = "4", icon="view_list", labelText="To-do", isChecked = false },
             -- { key = "Viewer", value = "4", labelText="View", isChecked = false } -- uncomment to see View as text
         }
     })


### PR DESCRIPTION
### Added
- "labelFont" option to createToolbar
- "labelText" option to createToolbar "list" of buttons. Allows a button to contain: Icon only, Text only or Icon with Text beneath.
### Change
- "x" option to createToolbar now works as expected. Set to 0 if wanting to use a toolbar that is 100% width of display.
- "width" option to createToolbar now works as expected. If width is omitted the toolbar width defaults to 100% or display.contentWidth
- "touchpoint" option to createToolbar now works as expected.
- "callBack" for createToolbar works as expected. It will do the animation and then call the user-defined callBack.
