### PR TITLE
createTableView now supports MUI widgets (attachToRow method). See ch…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.15] - 2016-07-03
+### Added
+- `onRowRenderDemo` - this is used to render the createTableView and add all the content on a row. 
+- `attachToRow` - For createTableView it will attach a MUI widget to a row. Supports widget types: RRectButton, RectButton, IconButton, Slider, TextField. Additional widget types will be added. See onRowRenderDemo for an example.
+- createTableView has option "rowAnimation = false" to turn off touchpoint and row fade.
+
+### Change
+- createSelect no longer needs onRowRender as param. It will handle rendering internally.
+- improved removal of widgets
+
 ## [0.1.14] - 2016-07-02
 ### Added
 - `createNavbar` - Create a navigation bar. Allows left and right alignment of attached widgets. See fun.lua for an example. Supports widget types: RRectButton, RectButton, IconButton, Slider, TextField. Additional widget types will be added.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Please read Lua code to find all parameters and see example in the repo call men
 Helper Methods
 -------------
 - `attachToNavBar` - attaches widget to navigation bar.
+- `attachToRow` - attaches widget to table view row.
 - `closeDialog` - closes an open dialog and releases memory
 - `getScaleVal` - returns integer scaled value to fit resolution. Useful for dimensions and coordinates.
 - `getWidgetByName` - returns the array of a named widget.

--- a/fun.lua
+++ b/fun.lua
@@ -109,7 +109,6 @@ function scene:create( event )
         x = mui.getScaleVal(240),
         y = mui.getScaleVal(350),
         callBackTouch = mui.onRowTouchSelector,
-        callBackRender = mui.onRowRender,
         scrollListener = nil,
         list = { -- if 'key' use it for 'id' in the table row
             { key = "Row1", text = "Apple", value = "Apple", isCategory = false },

--- a/menu.lua
+++ b/menu.lua
@@ -196,10 +196,11 @@ function scene:create( event )
         lineHeight = mui.getScaleVal(4),
         rowColor = { default={1,1,1}, over={1,0.5,0,0.2} },
         rowHeight = mui.getScaleVal(60),
+        -- rowAnimation = false, -- turn on rowAnimation
         noLines = false,
         callBackTouch = mui.onRowTouchDemo,
-        callBackRender = mui.onRowRender,
-        scrollListener = nil,
+        callBackRender = mui.onRowRenderDemo,
+        scrollListener = mui.scrollListener,  -- needed if using buttons, etc within the row!
         list = { -- if 'key' use it for 'id' in the table row
             { key = "Row1", text = "Row 1", value = "1", isCategory = false },
             { key = "Row2", text = "Row 2", value = "2", isCategory = false },
@@ -212,7 +213,7 @@ function scene:create( event )
         },
         categoryColor = { default={0.8,0.8,0.8,0.8} },
         categoryLineColor = { 1, 1, 1, 0 },
-        touchpointColor = { 0.4, 0.4, 0.4 }
+        touchpointColor = { 0.4, 0.4, 0.4 },
     })
     --]]--
 
@@ -265,13 +266,14 @@ function scene:create( event )
     mui.createToolbar({
         name = "toolbar_demo",
         --width = mui.getScaleVal(500), -- defaults to display.contentWidth
-        height = mui.getScaleVal(20),
+        height = mui.getScaleVal(70),
         buttonHeight = buttonHeight,
         x = 0,
         y = (display.contentHeight - (buttonHeight * 0.5)),
         layout = "horizontal",
         labelFont = native.systemFont,
         color = { 0.67, 0, 1 },
+        fillColor = { 0.67, 0, 1 },
         labelColor = { 1, 1, 1 },
         labelColorOff = { 0.41, 0.03, 0.49 },
         callBack = mui.actionForToolbarDemo,


### PR DESCRIPTION
## [0.1.15] - 2016-07-03
### Added
- `onRowRenderDemo` - this is used to render the createTableView and add all the content on a row. 
- `attachToRow` - For createTableView it will attach a MUI widget to a row. Supports widget types: RRectButton, RectButton, IconButton, Slider, TextField. Additional widget types will be added. See onRowRenderDemo for an example.
- createTableView has option "rowAnimation = false" to turn off touchpoint and row fade.
### Change
- createSelect no longer needs onRowRender as param. It will handle rendering internally.
- improved removal of widgets
