### PR TITLE
Renamed 'create' methods to 'new' and backwards compability kept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.23] - 2016-07-22
+### Change
+- Put back the toggle switch in the demo.
+- Renamed all methods with prefix 'create' to 'new'. Example newDialog() instead of createDialog(). Backwards compability will remain for a while. Any new methods will use 'new' prefix.
+- Renamed all methods with prefix 'removeWidget' to 'remove'.  Example removeDialog() instead of removeWidgetDialog(). Backwards compability will remain for a while. Any new methods will use 'remove' prefix.
+
 ## [0.1.22] - 2016-07-20
 ### Added
 - Added date and time pickers. This took a while to develop and will be improved.  There will be a another date and time picker following material lite design.  In the end there will be two sets to choose from.  See main scene with circle button icons for date and time.  Use method 'pickerGetCurrentValue(<control name>)' to get current date / time.

--- a/README.md
+++ b/README.md
@@ -69,25 +69,25 @@ Please read Lua code to find all parameters and see example in the repo call men
 
 | Method        | Short Description | Example  |
 | ------------- | ------------- | :-----:|
-| `createCircleButton` | Create a circle button with a single character or even a word.| menu.lua |
-| `createDatePicker` | Create a date picker. Use pickerGetCurrentValue() method to get current value in a table format. | menu.lua / mui-datetime.lua |
-| `createDialog` | Create a dialog (modal) with content. Supports up to two buttons (Okay, Cancel) with callbacks.       | menu.lua |
-| `createIconButton`      | Create an icon button using the material design icon font. Use this to create check boxes and more. | menu.lua |
-| `createNavbar`      | Create a navigation bar. Allows left and right alignment of attached widgets. Supports widget types: BasicText, CircleButton, IconButton, RRectButton, RectButton, Slider, TextField. Additional widget types will be added. | fun.lua |
-| `createProgressBar` | Create an animated progress bar using "determinate" from Material Design.      |    menu.lua |
-| `createRadioGroup` | Create a radio group with associated buttons.  It will automatically layout in vertical or horizontal formats with a series of radio buttons.      |    menu.lua |
-| `createRectButton` | Create a rectangle button      |    menu.lua/fun.lua |
-| `createRRectButton` | Create a rounded rectangle button     |    menu.lua/fun.lua |
-| `createSelect` | Create a select drop down list (dropdown list). Colors, dimensions and fonts can be specified.      |    fun.lua |
-| `createSlider()` | Create a slider for doing percentages 0..100. Calculate amount in call backs: callBackMove (called during movement) and callBack = at the end phase.  Values are in percent (0.20, 0.90 and 1 for 100%). See method sliderCallBackMove() to get current value of slider.       |    fun.lua |
-| `createTableView` | Create a scrollable table view      |    menu.lua/fun.lua |
-| `createTextBox` | Create a text box with label above (for now)      |    fun.lua |
-| `createTextField` | Create a text field with label above (for now)      |    menu.lua/fun.lua |
-| `createTimePicker` | Create a time picker. Use pickerGetCurrentValue() method to get current value in a table format. | menu.lua / mui-datetime.lua |
-| `createToast` | Create simple "toast" notifications on screen. Colors, dimensions and fonts can be specified.      |    fun.lua |
-| `createToggleSwitch` | Create a toggle switch.      |    menu.lua |
-| `createToolbar` | Create a horizontal toolbar with icon, text or icon + text (icon on top, text on bottom) buttons      |    menu.lua |
-| `createParentOnBoard` | Create an "onboarding" scene. The onboarding/walkthrough screens for first-time users. Introduce the app and demonstrate what it does. Used in conjunction with `addChildOnBoard`. Tap "?" in the demo's first scene. Supports progress indicators (rectangle and circles) Please "read" the comments near the top of the example. |    onboard.lua |
+| `newCircleButton` | Create a circle button with a single character or even a word.| menu.lua |
+| `newDatePicker` | Create a date picker. Use pickerGetCurrentValue() method to get current value in a table format. | menu.lua / mui-datetime.lua |
+| `newDialog` | Create a dialog (modal) with content. Supports up to two buttons (Okay, Cancel) with callbacks.       | menu.lua |
+| `newIconButton`      | Create an icon button using the material design icon font. Use this to create check boxes and more. | menu.lua |
+| `newNavbar`      | Create a navigation bar. Allows left and right alignment of attached widgets. Supports widget types: BasicText, CircleButton, IconButton, RRectButton, RectButton, Slider, TextField. Additional widget types will be added. | fun.lua |
+| `newProgressBar` | Create an animated progress bar using "determinate" from Material Design.      |    menu.lua |
+| `newRadioGroup` | Create a radio group with associated buttons.  It will automatically layout in vertical or horizontal formats with a series of radio buttons.      |    menu.lua |
+| `newRectButton` | Create a rectangle button      |    menu.lua/fun.lua |
+| `newRoundedRectButton` | Create a rounded rectangle button     |    menu.lua/fun.lua |
+| `newSelect` | Create a select drop down list (dropdown list). Colors, dimensions and fonts can be specified.      |    fun.lua |
+| `newSlider` | Create a slider for doing percentages 0..100. Calculate amount in call backs: callBackMove (called during movement) and callBack = at the end phase.  Values are in percent (0.20, 0.90 and 1 for 100%). See method sliderCallBackMove() to get current value of slider.       |    fun.lua |
+| `newTableView` | Create a scrollable table view      |    menu.lua/fun.lua |
+| `newTextBox` | Create a text box with label above (for now)      |    fun.lua |
+| `newTextField` | Create a text field with label above (for now)      |    menu.lua/fun.lua |
+| `newTimePicker` | Create a time picker. Use pickerGetCurrentValue() method to get current value in a table format. | menu.lua / mui-datetime.lua |
+| `newToast` | Create simple "toast" notifications on screen. Colors, dimensions and fonts can be specified.      |    fun.lua |
+| `newToggleSwitch` | Create a toggle switch.      |    menu.lua |
+| `newToolbar` | Create a horizontal toolbar with icon, text or icon + text (icon on top, text on bottom) buttons      |    menu.lua |
+| `newParentOnBoard` | Create an "onboarding" scene. The onboarding/walkthrough screens for first-time users. Introduce the app and demonstrate what it does. Used in conjunction with `addChildOnBoard`. Tap "?" in the demo's first scene. Supports progress indicators (rectangle and circles) Please "read" the comments near the top of the example. |    onboard.lua |
 
 Helper Methods
 -------------
@@ -101,25 +101,25 @@ Helper Methods
 - `hideWidget` - hide a widget by name. It will hide/show a widget by setting the isVisible attribute.
 
 Remove widget methods - these will remove the widget by name and release memory:
-- `removeWidgetCircleButton`
-- `removeWidgetDialog`
-- `removeWidgetIconButton`
-- `removeWidgetNavbar`
-- `removeWidgetOnBoarding`
-- `removeWidgetProgressBar`
-- `removeWidgetRadioButton`
-- `removeWidgetRectButton`
-- `removeWidgetRRectButton`
-- `removeWidgetSelect`
-- `removeWidgetSlider`
-- `removeWidgetSwitch`
-- `removeWidgetTableView`
-- `removeWidgetTextField`
-- `removeWidgetTextBox`
-- `removeWidgetToast`
-- `removeWidgetToggleSwitch`
-- `removeWidgetToolbar`
-- `removeWidgetToolbarButton`
+- `removeCircleButton`
+- `removeDialog`
+- `removeIconButton`
+- `removeNavbar`
+- `removeOnBoarding`
+- `removeProgressBar`
+- `removeRadioButton`
+- `removeRectButton`
+- `removeRRectButton`
+- `removeSelect`
+- `removeSlider`
+- `removeSwitch`
+- `removeTableView`
+- `removeTextField`
+- `removeTextBox`
+- `removeToast`
+- `removeToggleSwitch`
+- `removeToolbar`
+- `removeToolbarButton`
 
 Built-In Callbacks
 -------------

--- a/fun.lua
+++ b/fun.lua
@@ -47,7 +47,7 @@ function scene:create( event )
 	background:setFillColor( unpack(colorFill) )
 
     mui.init()
-    mui.createRRectButton({
+    mui.newRoundedRectButton({
         scrollView = scrollView,
         name = "goBack",
         text = "Go Back",
@@ -68,7 +68,7 @@ function scene:create( event )
     -- show a "toast" message, yes I said toast like HTML 5 Toast
     -- recommend 40 percent ratio for one liners (20 radius/50 height = 0.40)
     local showToast = function()
-        mui.createToast({
+        mui.newToast({
             name = "toast_demo",
             text = "New Messages!",
             radius = 20,
@@ -85,7 +85,7 @@ function scene:create( event )
         })
     end
 
-    mui.createRRectButton({
+    mui.newRoundedRectButton({
         name = "newToast",
         text = "Show Toast",
         width = mui.getScaleVal(200),
@@ -101,7 +101,7 @@ function scene:create( event )
 
     -- create a drop down list
     local numOfRowsToShow = 3
-    mui.createSelect({
+    mui.newSelect({
         name = "selector_demo1",
         labelText = "Favorite Food",
         text = "Apple",
@@ -136,7 +136,7 @@ function scene:create( event )
 
     -- horizontal slider (vertical in development)
     ---[[--
-    mui.createSlider({
+    mui.newSlider({
         name = "slider_demo",
         width = mui.getScaleVal(200),
         height = mui.getScaleVal(4),
@@ -149,7 +149,7 @@ function scene:create( event )
         callBackMove = mui.sliderCallBackMove,
         callBack = mui.sliderCallBack
     })
-    mui.createSlider({
+    mui.newSlider({
         name = "slider_demo2",
         width = mui.getScaleVal(200),
         height = mui.getScaleVal(4),
@@ -179,7 +179,7 @@ function scene:create( event )
 	    }
 	)
 
-    mui.createTextField({
+    mui.newTextField({
         name = "textfield_demo2",
         labelText = "Subject",
         text = "Hello, world!",
@@ -195,7 +195,7 @@ function scene:create( event )
     })
     --]]--
 
-    mui.createTextField({
+    mui.newTextField({
         name = "textfield_demo3",
         labelText = "Tweet",
         text = "Scroll away",
@@ -211,7 +211,7 @@ function scene:create( event )
         isSecure = true
     })
 
-    mui.createTextField({
+    mui.newTextField({
         name = "textfield_demo4",
         labelText = "My Topic",
         text = "Hello, World!",
@@ -226,7 +226,7 @@ function scene:create( event )
         scrollView = scrollView
     })
 
-    mui.createTextField({
+    mui.newTextField({
         name = "textfield_demo5",
         labelText = "Numbers Only",
         text = "12345",
@@ -242,7 +242,7 @@ function scene:create( event )
         inputType = "number"
     })
 
-    mui.createTextBox({
+    mui.newTextBox({
         name = "textbox_demo1",
         labelText = "Secret Text Box",
         text = "I am hidden in view\nYes, me too!\nFood\nDrink\nDesert",
@@ -275,7 +275,7 @@ function scene:create( event )
 
     -- put navbar on bottom. this is to stay on top of other widgets.
     -- supported widget types are : "RRectButton", "RectButton", "IconButton", "Slider", "TextField"
-    mui.createNavbar({
+    mui.newNavbar({
         name = "navbar_demo",
         --width = mui.getScaleVal(500), -- defaults to display.contentWidth
         height = mui.getScaleVal(70),
@@ -285,7 +285,7 @@ function scene:create( event )
         activeTextColor = { 1, 1, 1, 1 },
         padding = mui.getScaleVal(10),
     })
-    mui.createIconButton({
+    mui.newIconButton({
         name = "menu",
         text = "menu",
         width = mui.getScaleVal(50),
@@ -302,7 +302,7 @@ function scene:create( event )
         widgetType = "IconButton",
         align = "left",  -- left | right supported
     })
-    mui.createIconButton({
+    mui.newIconButton({
         name = "refresh",
         text = "refresh",
         width = mui.getScaleVal(50),
@@ -319,7 +319,7 @@ function scene:create( event )
         widgetType = "IconButton",
         align = "left",  -- left | right supported
     })
-    mui.createTextField({
+    mui.newTextField({
         name = "textfield_nav",
         text = "",
         placeholder = "Search",
@@ -338,7 +338,7 @@ function scene:create( event )
         widgetType = "TextField",
         align = "left",  -- left | right supported
     })
-    mui.createIconButton({
+    mui.newIconButton({
         name = "help",
         text = "help",
         width = mui.getScaleVal(50),

--- a/materialui/mui-base.lua
+++ b/materialui/mui-base.lua
@@ -86,12 +86,12 @@ function M.eventSuperListner(event)
                 if muiData.widgetDict[muiData.currentTargetName]["mygroup"] ~= nil then
                     muiData.currentTargetName = nil
                     muiData.lastTargetName = ""
-                    M.removeWidgetSelector(widget, "listonly")
+                    M.removeSelector(widget, "listonly")
                 end
                 break
             elseif widgetType == "Selector" and muiData.widgetDict[widget] ~= nil then
                 if muiData.widgetDict[widget]["mygroup"] ~= nil and muiData.widgetDict[widget]["mygroup"].isVisible == true then
-                    M.removeWidgetSelector(widget, "listonly")
+                    M.removeSelector(widget, "listonly")
                 end
             end
         end
@@ -538,48 +538,48 @@ function M.removeWidgets()
       local widgetType = muiData.widgetDict[widget]["type"]
       if widgetType ~= nil and muiData.widgetDict[widget] ~= nil then
         if widgetType == "CircleButton" then
-            M.removeWidgetCircleButton(widget)
+            M.removeCircleButton(widget)
         elseif widgetType == "DatePicker" then
-            M.removeWidgetDatePicker(widget)
+            M.removeDatePicker(widget)
         elseif widgetType == "RRectButton" then
-            M.removeWidgetRRectButton(widget)
+            M.removeRRectButton(widget)
         elseif widgetType == "RectButton" then
-            M.removeWidgetRectButton(widget)
+            M.removeRectButton(widget)
         elseif widgetType == "IconButton" then
-            M.removeWidgetIconButton(widget)
+            M.removeIconButton(widget)
         elseif widgetType == "RadioButton" then
-            M.removeWidgetRadioButton(widget)
+            M.removeRadioButton(widget)
         elseif widgetType == "Toolbar" then
-            M.removeWidgetToolbar(widget)
+            M.removeToolbar(widget)
         elseif widgetType == "TableView" then
-            M.removeWidgetTableView(widget)
+            M.removeTableView(widget)
         elseif widgetType == "TextField" then
-            M.removeWidgetTextField(widget)
+            M.removeTextField(widget)
         elseif widgetType == "TextBox" then
-            M.removeWidgetTextBox(widget)
+            M.removeTextBox(widget)
         elseif widgetType == "TimePicker" then
-            M.removeWidgetTimePicker(widget)
+            M.removeTimePicker(widget)
         elseif widgetType == "ProgressBar" then
-            M.removeWidgetProgressBar(widget)
+            M.removeProgressBar(widget)
         elseif widgetType == "ToggleSwitch" then
-            M.removeWidgetToggleSwitch(widget)
+            M.removeToggleSwitch(widget)
         elseif widgetType == "Slider" then
-            M.removeWidgetSlider(widget)
+            M.removeSlider(widget)
         elseif widgetType == "Toast" then
-            M.removeWidgetToast(widget)
+            M.removeToast(widget)
         elseif widgetType == "Selector" then
-            M.removeWidgetSelector(widget)
+            M.removeSelector(widget)
         elseif widgetType == "Navbar" then
             M.removeNavbar(widget)
         elseif widgetType == "BasicText" then
-            M.removeWidgetBasicText(widget)
+            M.removeBasicText(widget)
         end
       end
   end
 
   -- remove onBoarding if used.
   if muiData.onBoardData ~= nil then
-    M.removeWidgetOnBoarding()
+    M.removeOnBoarding()
   end
 
   -- remove circle if present

--- a/materialui/mui-button.lua
+++ b/materialui/mui-button.lua
@@ -60,6 +60,10 @@ local M = muiData.M -- {} -- for module array/table
 
 ]]
 function M.createRRectButton(options)
+    M.newRoundedRectButton(options)
+end
+
+function M.newRoundedRectButton(options)
 
     local x,y = 160, 240
     if options.x ~= nil then
@@ -276,6 +280,10 @@ end
 
 ]]
 function M.createRectButton(options)
+    M.newRectButton(options)
+end
+
+function M.newRectButton(options)
 
     local x,y = 160, 240
     if options.x ~= nil then
@@ -404,6 +412,10 @@ end
 
 ]]
 function M.createIconButton(options)
+    M.newIconButton(options)
+end
+
+function M.newIconButton(options)
 
     local x,y = 160, 240
     if options.x ~= nil then
@@ -564,7 +576,11 @@ function M.touchIconButton (event)
 end
 
 function M.createCheckBox(options)
-    M.createIconButton({
+    M.newCheckBox(options)
+end
+
+function M.newCheckBox(options)
+    M.newIconButton({
         name = options.name,
         text = "check_box_outline_blank",
         width = options.width,
@@ -579,6 +595,10 @@ function M.createCheckBox(options)
 end
 
 function M.createCircleButton(options)
+    M.newCircleButton(options)
+end
+
+function M.newCircleButton(options)
 
     local x,y = 160, 240
     if options.x ~= nil then
@@ -763,6 +783,10 @@ end
 
 ]]
 function M.createRadioButton(options)
+    M.newRadioButton(options)
+end
+
+function M.newRadioButton(options)
 
     local x,y = 160, 240
     if options.x ~= nil then
@@ -970,8 +994,11 @@ function M.touchCheckbox (event)
     end
 end
 
-
 function M.createRadioGroup(options)
+    M.newRadioGroup(options)
+end
+
+function M.newRadioGroup(options)
 
     local x, y = options.x, options.y
 
@@ -989,7 +1016,7 @@ function M.createRadioGroup(options)
         muiData.widgetDict[options.name]["radio"] = {}
         muiData.widgetDict[options.name]["type"] = "RadioGroup"
         for i, v in ipairs(options.list) do            
-            M.createRadioButton({
+            M.newRadioButton({
                 name = options.name .. "_" .. i,
                 basename = options.name,
                 label = v.key,
@@ -1090,6 +1117,10 @@ function M.actionForButton( e )
 end
 
 function M.removeWidgetRRectButton(widgetName)
+    M.removeRRectButton(widgetName)
+end
+
+function M.removeRRectButton(widgetName)
     if widgetName == nil then
         return
     end
@@ -1111,6 +1142,10 @@ function M.removeWidgetRRectButton(widgetName)
 end
 
 function M.removeWidgetRectButton(widgetName)
+    M.removeRectButton(widgetName)
+end
+
+function M.removeRectButton(widgetName)
     if widgetName == nil then
         return
     end
@@ -1130,6 +1165,10 @@ function M.removeWidgetRectButton(widgetName)
 end
 
 function M.removeWidgetCircleButton(widgetName)
+    M.removeCircleButton(widgetName)
+end
+
+function M.removeCircleButton(widgetName)
     if widgetName == nil then
         return
     end
@@ -1149,6 +1188,10 @@ function M.removeWidgetCircleButton(widgetName)
 end
 
 function M.removeWidgetIconButton(widgetName)
+    M.removeIconButton(widgetName)
+end
+
+function M.removeIconButton(widgetName)
     if widgetName == nil then
         return
     end
@@ -1166,6 +1209,10 @@ function M.removeWidgetIconButton(widgetName)
 end
 
 function M.removeWidgetRadioButton(widgetName)
+    M.removeRadioButton(widgetName)
+end
+
+function M.removeRadioButton(widgetName)
     if widgetName == nil then
         return
     end

--- a/materialui/mui-datetime.lua
+++ b/materialui/mui-datetime.lua
@@ -45,6 +45,10 @@ local M = muiData.M -- {} -- for module array/table
 
 -- define methods here
 function M.createDatePicker(options)
+    M.newDatePicker(options)
+end
+
+function M.newDatePicker(options)
 	if options == nil then return end
     if muiData.widgetDict[options.name] ~= nil then return end
 
@@ -205,7 +209,7 @@ function M.createDatePicker(options)
         callBack = options.callBack,
     }
 
-    M.createPickerWheel(options.x, options.y, pickerOptions)
+    M.newPickerWheel(options.x, options.y, pickerOptions)
 end
 
 function M.datePickerCallBack( event )
@@ -221,7 +225,7 @@ function M.datePickerCallBack( event )
         local text = "Date Column 1 Value: " .. (value.month or "") .. "\nColumn 2 Value: " .. (value.day or "") .. "\nColumn 3 Value: " .. (value.year or "")
         print("text: "..text)
     end
-    M.removeWidgetDateTimePicker(event)
+    M.removeDateTimePicker(event)
 
     return true
 end
@@ -271,6 +275,10 @@ end
 
 -- define methods here
 function M.createTimePicker(options)
+    M.newTimePicker(options)
+end
+
+function M.newTimePicker(options)
     if options == nil then return end
     if muiData.widgetDict[options.name] ~= nil then return end
 
@@ -429,7 +437,7 @@ function M.createTimePicker(options)
         submitButtonTextColor = options.submitButtonTextColor,
         callBack = options.callBack,
     }
-    M.createPickerWheel(options.x, options.y, pickerOptions)
+    M.newPickerWheel(options.x, options.y, pickerOptions)
 end
 
 function M.pickerSetDefaultOptions(options)
@@ -444,7 +452,7 @@ function M.pickerSetDefaultOptions(options)
     return options
 end
 
-function M.createPickerWheel( x, y, options )
+function M.newPickerWheel( x, y, options )
     if options == nil then return end
     if options.name == nil then return end
 
@@ -654,7 +662,7 @@ function M.createPickerWheel( x, y, options )
     muiData.dialogInUse = true
 
     -- attach the cancel button
-    M.createRectButton({
+    M.newRectButton({
         name = options.name .. "-datetime-button-cancel",
         dialogName = options.name,
         text = (options.cancelButtonText or "Cancel"),
@@ -666,7 +674,7 @@ function M.createPickerWheel( x, y, options )
         fillColor = (options.cancelButtonFillColor or { 0, 0, 1, 1 }),
         textColor = (options.cancelButtonTextColor or { 1, 1, 1 }),
         touchpoint = true,
-        callBack = M.removeWidgetDateTimePicker,
+        callBack = M.removeDateTimePicker,
         callBackData = {
             targetName = options.name,
             buttonName = options.name .. "-datetime-button-cancel"
@@ -678,7 +686,7 @@ function M.createPickerWheel( x, y, options )
     cancelWidget.y = cancelWidget.y + (cancelWidget.contentHeight * 0.95)
 
     -- attach the set button
-    M.createRectButton({
+    M.newRectButton({
         name = options.name .. "-datetime-button-set",
         dialogName = options.name,
         text = (options.submitButtonText or "Set"),
@@ -1013,12 +1021,16 @@ function M.timePickerCallBack( event )
         print("text: "..text)
 
     end
-    M.removeWidgetDateTimePicker(event)
+    M.removeDateTimePicker(event)
 
     return true
 end
 
 function M.removeWidgetDateTimePicker( event )
+    M.removeDateTimePicker( event )
+end
+
+function M.removeDateTimePicker( event )
     local callBackData = M.getEventParameter(event, "muiTargetCallBackData")
     if callBackData == nil then return end
 
@@ -1029,8 +1041,8 @@ function M.removeWidgetDateTimePicker( event )
 
     if muiData.widgetDict[widgetName] == nil then return end
 
-    M.removeWidgetRectButton(widgetName .. "-datetime-button-cancel")
-    M.removeWidgetRectButton(widgetName .. "-datetime-button-set")
+    M.removeRectButton(widgetName .. "-datetime-button-cancel")
+    M.removeRectButton(widgetName .. "-datetime-button-set")
 
     muiData.widgetDict[widgetName]["line-top"]:removeSelf()
     muiData.widgetDict[widgetName]["line-top"] = nil

--- a/materialui/mui-dialog.lua
+++ b/materialui/mui-dialog.lua
@@ -40,6 +40,10 @@ local mathABS = math.abs
 local M = muiData.M -- {} -- for module array/table
 
 function M.createDialog(options)
+    M.newDialog(options)
+end
+
+function M.newDialog(options)
 
     if options == nil then return end
 
@@ -188,7 +192,7 @@ function M.createDialog(options)
         if options.buttons["okayButton"].text == nil then
             options.buttons["okayButton"].text = "Okay"
         end
-        M.createRectButton({
+        M.newRectButton({
             name = "okay_dialog_button",
             text = options.buttons["okayButton"].text,
             width = M.getScaleVal(100),
@@ -224,7 +228,7 @@ function M.createDialog(options)
         if bx > 0 then
             bx = (bx - (bx * 0.1)) - M.getScaleVal(100)
         end
-        M.createRectButton({
+        M.newRectButton({
             name = "cancel_dialog_button",
             text = options.buttons["cancelButton"].text,
             width = M.getScaleVal(100),
@@ -271,7 +275,7 @@ function M.closeDialog(e)
     -- fade out and destroy it
     if muiData.dialogName ~= nil then
         transition.fadeOut( muiData.widgetDict[muiData.dialogName]["rectbackdrop"], { time=500 } )
-        transition.to( muiData.widgetDict[muiData.dialogName]["container"], { time=1100, y = display.contentHeight * 2, onComplete=M.removeWidgetDialog, transition=easing.inOutCubic } )
+        transition.to( muiData.widgetDict[muiData.dialogName]["container"], { time=1100, y = display.contentHeight * 2, onComplete=M.removeDialog, transition=easing.inOutCubic } )
     end
 end
 
@@ -281,6 +285,10 @@ function M.dialogClose(e)
 end
 
 function M.removeWidgetDialog()
+    M.removeDialog()
+end
+
+function M.removeDialog()
     if muiData.dialogName == nil then
         return
     end
@@ -289,8 +297,8 @@ function M.removeWidgetDialog()
     if muiData.widgetDict[widgetName] == nil then return end
 
     -- remove buttons
-    M.removeWidgetRectButton("okay_dialog_button")
-    M.removeWidgetRectButton("cancel_dialog_button")
+    M.removeRectButton("okay_dialog_button")
+    M.removeRectButton("cancel_dialog_button")
 
     -- remove the rest
     -- muiData.widgetDict[widgetName]["container"]["myText"]:removeSelf()

--- a/materialui/mui-navbar.lua
+++ b/materialui/mui-navbar.lua
@@ -47,6 +47,10 @@ function M.getNavbarSupportedTypes()
 end
 
 function M.createNavbar( options )
+    M.newNavBar(options)
+end
+
+function M.newNavbar( options )
     if options == nil then return end
 
     if muiData.widgetDict[options.name] ~= nil then return end
@@ -189,17 +193,17 @@ function M.removeNavbar(widgetName)
     for name, widgetType in pairs(muiData.widgetDict[widgetName]["list"]) do
         if muiData.widgetDict[widgetName]["list"][name] ~= nil then
             if widgetType == "RRectButton" then
-                M.removeWidgetRRectButton(name)
+                M.removeRRectButton(name)
             elseif widgetType == "RectButton" then
-                M.removeWidgetRectButton(name)
+                M.removeRectButton(name)
             elseif widgetType == "CircleButton" then
-                M.removeWidgetCircleButton(name)
+                M.removeCircleButton(name)
             elseif widgetType == "IconButton" then
-                M.removeWidgetIconButton(name)
+                M.removeIconButton(name)
             elseif widgetType == "RectButton" then
-                M.removeWidgetSlider(name)
+                M.removeSlider(name)
             elseif widgetType == "RectButton" then
-                M.removeWidgetTextField(name)
+                M.removeTextField(name)
             elseif widgetType == "Generic" then
               if muiData.widgetDict[widgetName]["destroy"] ~= nil and muiData.widgetDict[widgetName]["destroy"][name] ~= nil then
                 assert( muiData.widgetDict[widgetName]["destroy"][name] )(event)

--- a/materialui/mui-onboarding.lua
+++ b/materialui/mui-onboarding.lua
@@ -14,6 +14,10 @@ local screenH = display.contentHeight
 local M = muiData.M -- {} -- for module array/table
 
 function M.createParentOnBoard( options )
+    return M.newParentOnBoard(options)
+end
+
+function M.newParentOnBoard( options )
 	if options == nil then return end
 
 	if muiData.onBoardData == nil then muiData.onBoardData = {} end
@@ -120,6 +124,10 @@ function M.transitionSlideForOnBoard(i, obj, slideConfig)
 end
 
 function M.createElipsesForProgress( options )
+    M.newElipsesForProgress( options )
+end
+
+function M.newElipsesForProgress( options )
 	if options == nil then return end
 	if options.parent == nil or options.group == nil then return end
 	if options.slides ~= nil and options.slides < 2 then return end
@@ -205,6 +213,10 @@ function M.updateSlideIndicator()
 end
 
 function M.removeWidgetOnBoarding()
+    M.removeOnBoarding()
+end
+
+function M.removeOnBoarding()
     if muiData.onBoardData == nil then return end
 
     for i, groups in pairs(muiData.onBoardData) do

--- a/materialui/mui-progressbar.lua
+++ b/materialui/mui-progressbar.lua
@@ -64,6 +64,10 @@ local M = muiData.M -- {} -- for module array/table
     hideBackdropWhenDone = false
 --]]--
 function M.createProgressBar(options)
+    M.newProgressBar(options)
+end
+
+function M.newProgressBar(options)
     if options == nil then return end
 
     local x,y = 160, 240
@@ -264,6 +268,10 @@ function M.postProgressCallBack( object )
 end
 
 function M.removeWidgetProgressBar(widgetName)
+    M.removeProgressBar(widgetName)
+end
+
+function M.removeProgressBar(widgetName)
     if widgetName == nil then
         return
     end

--- a/materialui/mui-select.lua
+++ b/materialui/mui-select.lua
@@ -42,12 +42,19 @@ local mathABS = math.abs
 
 local M = muiData.M -- {} -- for module array/table
 
-
 function M.createDropDown(options)
-    M.createSelector(options)
+    M.newDropDown(options)
+end
+
+function M.newDropDown(options)
+    M.newSelect(options)
 end
 
 function M.createSelect(options)
+    M.newSelect(options)
+end
+
+function M.newSelect(options)
 
     local x,y = 160, 240
     if options.x ~= nil then
@@ -188,7 +195,7 @@ function M.revealTableViewForSelector(name, options)
     muiData.widgetDict[options.name]["mygroup"].x = x
     muiData.widgetDict[options.name]["mygroup"].y = y
 
-    M.createTableView({
+    M.newTableView({
         name = options.name.."-List",
         width = options.width - M.getScaleVal(5),
         height = options.listHeight,
@@ -291,10 +298,14 @@ end
 
 function M.finishSelector(parentName)
     if muiData.widgetDict[parentName] == nil then return end
-    M.removeWidgetSelector(parentName, "listonly")
+    M.removeSelector(parentName, "listonly")
 end
 
 function M.removeWidgetSelector(widgetName, listonly)
+    M.removeSelector(widgetName, listonly)
+end
+
+function M.removeSelector(widgetName, listonly)
     if widgetName == nil then
         return
     end
@@ -302,11 +313,11 @@ function M.removeWidgetSelector(widgetName, listonly)
     if muiData.widgetDict[widgetName] == nil then return end
 
     if listonly ~= nil then
-        M.removeWidgetTableView(widgetName .. "-List")
+        M.removeTableView(widgetName .. "-List")
         M.removeSelectorGroup(widgetName)
         return
     else
-        M.removeWidgetTableView(widgetName .. "-List")
+        M.removeTableView(widgetName .. "-List")
     end
 
     muiData.widgetDict[widgetName]["selectorfieldfake"]:removeEventListener("touch", M.selectorListener)

--- a/materialui/mui-slider.lua
+++ b/materialui/mui-slider.lua
@@ -40,6 +40,10 @@ local mathABS = math.abs
 local M = muiData.M -- {} -- for module array/table
 
 function M.createSlider(options)
+    M.newSlider(options)
+end
+
+function M.newSlider(options)
     if options == nil then return end
 
     local x,y = 160, 240
@@ -265,6 +269,10 @@ function M.sliderCallBack( event )
 end
 
 function M.removeWidgetSlider(widgetName)
+    M.removeSlider(widgetName)
+end
+
+function M.removeSlider(widgetName)
     if widgetName == nil then
         return
     end

--- a/materialui/mui-switch.lua
+++ b/materialui/mui-switch.lua
@@ -40,6 +40,10 @@ local mathABS = math.abs
 local M = muiData.M -- {} -- for module array/table
 
 function M.createToggleSwitch(options)
+    M.newToggleSwitch(options)
+end
+
+function M.newToggleSwitch(options)
     if options == nil then return end
 
     local x,y = 160, 240
@@ -239,6 +243,10 @@ function M.actionForSwitch(event)
 end
 
 function M.removeWidgetToggleSwitch(widgetName)
+    M.removeToggleSwitch(widgetName)
+end
+
+function M.removeToggleSwitch(widgetName)
     if widgetName == nil then
         return
     end

--- a/materialui/mui-tableview.lua
+++ b/materialui/mui-tableview.lua
@@ -43,6 +43,10 @@ local mathABS = math.abs
 local M = muiData.M -- {} -- for module array/table
 
 function M.createTableView( options )
+    M.newTableView( options )
+end
+
+function M.newTableView( options )
     local screenRatio = M.getSizeRatio()
     -- The "onRowRender" function may go here (see example under "Inserting Rows", above)
 
@@ -239,7 +243,7 @@ function M.onRowRenderDemo( event )
     local rowWidth = row.contentWidth
 
     --[[-- demo attaching widget to a row
-    M.createIconButton({
+    M.newIconButton({
         name = "plus"..row.index,
         text = "add_circle",
         width = M.getScaleVal(40),
@@ -393,6 +397,10 @@ function M.onRowTouchDemo(event)
 end
 
 function M.removeWidgetTableView(widgetName)
+    M.removeTableView(widgetName)
+end
+
+function M.removeTableView(widgetName)
     if widgetName == nil then
         return
     end

--- a/materialui/mui-text.lua
+++ b/materialui/mui-text.lua
@@ -41,6 +41,10 @@ local M = muiData.M -- {} -- for module array/table
 
 -- define methods here
 function M.createBasicText(options)
+    M.newBasicText(options)
+end
+
+function M.newBasicText(options)
 	if options == nil then return end
 
     muiData.widgetDict[options.name] = {}
@@ -52,6 +56,10 @@ function M.createBasicText(options)
 end
 
 function M.removeWidgetBasicText(widgetName)
+    M.removeBasicText(widgetName)
+end
+
+function M.removeBasicText(widgetName)
     if widgetName == nil then
         return
     end

--- a/materialui/mui-textinput.lua
+++ b/materialui/mui-textinput.lua
@@ -43,6 +43,10 @@ local M = muiData.M -- {} -- for module array/table
 -- To-do: flow right or below based on parent text widget
 --
 function M.createTextField(options)
+    M.newTextField(options)
+end
+
+function M.newTextField(options)
 
     local x,y = 160, 240
     if options.x ~= nil then
@@ -279,6 +283,10 @@ end
 -- To-do: flow right or below based on parent text widget
 --
 function M.createTextBox(options)
+    M.newTextBox(options)
+end
+
+function M.newTextBox(options)
 
     local x,y = 160, 240
     if options.x ~= nil then
@@ -401,6 +409,10 @@ function M.textfieldCallBack(event)
 end
 
 function M.removeWidgetTextField(widgetName)
+    M.removeTextField(widgetName)
+end
+
+function M.removeTextField(widgetName)
     if widgetName == nil then
         return
     end
@@ -429,7 +441,11 @@ function M.removeWidgetTextField(widgetName)
 end
 
 function M.removeWidgetTextBox(widgetName)
-    M.removeWidgetTextField(widgetName)
+    M.removeTextBox(widgetName)
+end
+
+function M.removeTextBox(widgetName)
+    M.removeTextField(widgetName)
 end
 
 return M

--- a/materialui/mui-toast.lua
+++ b/materialui/mui-toast.lua
@@ -43,6 +43,10 @@ local mathABS = math.abs
 local M = muiData.M -- {} -- for module array/table
 
 function M.createToast( options )
+    M.newToast( options )
+end
+
+function M.newToast( options )
     if options == nil then return end
 
     if muiData.widgetDict[options.name] ~= nil then return end
@@ -155,7 +159,7 @@ function M.createToast( options )
                         options.easingOut = 500
                     end
                     muiData.widgetDict[options.name]["container"].name = options.name
-                    transition.to(muiData.widgetDict[options.name]["container"],{time=options.easingOut, y=-(options.top), transition=easing.inOutCubic, onComplete=M.removeToast})
+                    transition.to(muiData.widgetDict[options.name]["container"],{time=options.easingOut, y=-(options.top), transition=easing.inOutCubic, onComplete=M.removeMyToast})
                     event.target = muiData.widgetDict[options.name]["rrect"]
                     event.callBackData = options.callBackData
 
@@ -178,14 +182,18 @@ function M.createToast( options )
     transition.to(muiData.widgetDict[options.name]["container"],{time=options.easingIn, y=options.top, transition=easing.inOutCubic})
 end
 
-function M.removeToast(event)
+function M.removeMyToast(event)
     local muiName = event.name
     if muiName ~= nil then
-        M.removeWidgetToast(muiName)
+        M.removeToast(muiName)
     end
 end
 
 function M.removeWidgetToast(widgetName)
+    M.removeToast(widgetName)
+end
+
+function M.removeToast(widgetName)
     if widgetName == nil then
         return
     end

--- a/materialui/mui-toolbar.lua
+++ b/materialui/mui-toolbar.lua
@@ -40,6 +40,10 @@ local mathABS = math.abs
 local M = muiData.M -- {} -- for module array/table
 
 function M.createToolbarButton( options )
+    M.newToolbarButton( options )
+end
+
+function M.newToolbarButton( options )
     local x,y = 160, 240
     if options.x ~= nil then
         x = options.x
@@ -304,6 +308,10 @@ function M.toolBarButton (event)
 end
 
 function M.createToolbar( options )
+  M.newToolbar( options )
+end
+
+function M.newToolbar( options )
     local x, y = options.x, options.y
     local buttonWidth = 1
     local buttonOffset = 0
@@ -323,7 +331,7 @@ function M.createToolbar( options )
         muiData.widgetDict[options.name]["toolbar"] = {}
         muiData.widgetDict[options.name]["type"] = "Toolbar"
         for i, v in ipairs(options.list) do            
-            M.createToolbarButton({
+            M.newToolbarButton({
                 index = i,
                 name = options.name .. "_" .. i,
                 basename = options.name,
@@ -421,6 +429,10 @@ function M.actionForToolbarDemo( event )
 end
 
 function M.removeWidgetToolbar(widgetName)
+    M.removeToolbar(widgetName)
+end
+
+function M.removeToolbar(widgetName)
     if widgetName == nil then
         return
     end
@@ -428,7 +440,7 @@ function M.removeWidgetToolbar(widgetName)
     if muiData.widgetDict[widgetName] == nil then return end
 
     for name in pairs(muiData.widgetDict[widgetName]["toolbar"]) do
-        M.removeWidgetToolbarButton(muiData.widgetDict, widgetName, name)
+        M.removeToolbarButton(muiData.widgetDict, widgetName, name)
         if name ~= "slider" and name ~= "rectBak" then
             muiData.widgetDict[widgetName]["toolbar"][name] = nil
         end
@@ -444,6 +456,10 @@ function M.removeWidgetToolbar(widgetName)
 end
 
 function M.removeWidgetToolbarButton(widgetDict, toolbarName, name)
+    M.removeToolbarButton(widgetDict, toolbarName, name)
+end
+
+function M.removeToolbarButton(widgetDict, toolbarName, name)
     if toolbarName == nil then
         return
     end

--- a/menu.lua
+++ b/menu.lua
@@ -45,7 +45,7 @@ function scene:create( event )
     -- dialog box example
     -- use mui.getWidgetBaseObject("dialog_demo") to get surface to add more content
     local showDialog = function()
-        mui.createDialog({
+        mui.newDialog({
             name = "dialog_demo",
             width = mui.getScaleVal(450),
             height = mui.getScaleVal(300),
@@ -88,7 +88,7 @@ function scene:create( event )
         })
     end
 
-    mui.createRRectButton({
+    mui.newRoundedRectButton({
         name = "newDialog",
         text = "Open Dialog",
         width = mui.getScaleVal(200),
@@ -104,7 +104,7 @@ function scene:create( event )
         callBack = showDialog
     })
 
-    mui.createRectButton({
+    mui.newRectButton({
         name = "scene2",
         text = "Switch Scene",
         width = mui.getScaleVal(200),
@@ -122,7 +122,7 @@ function scene:create( event )
         } -- scene fun.lua
     })
 
-    mui.createIconButton({
+    mui.newIconButton({
         name = "plus",
         text = "help",
         width = mui.getScaleVal(50),
@@ -142,7 +142,7 @@ function scene:create( event )
 
     -- date picker example
     local showDatePicker = function(event)
-        mui.createDatePicker({
+        mui.newDatePicker({
             name = "datepicker-demo",
             font = native.systemFont,
             fontSize = mui.getScaleVal(26),
@@ -169,7 +169,7 @@ function scene:create( event )
             callBack = mui.datePickerCallBack,
         })
     end
-    mui.createCircleButton({
+    mui.newCircleButton({
         name = "alice-button",
         text = "date_range",
         radius = mui.getScaleVal(46),
@@ -187,7 +187,7 @@ function scene:create( event )
 
     -- time picker example
     local showTimePicker = function(event)
-        mui.createTimePicker({
+        mui.newTimePicker({
             name = "timepicker-demo",
             font = native.systemFont,
             width = mui.getScaleVal(400),
@@ -211,7 +211,7 @@ function scene:create( event )
             callBack = mui.timePickerCallBack,
         })
     end
-    mui.createCircleButton({
+    mui.newCircleButton({
         name = "bueler-button",
         text = "access_time",
         radius = mui.getScaleVal(46),
@@ -225,7 +225,7 @@ function scene:create( event )
     })
 
     -- simulates a checkbox but can be other toggle buttons too!
-    mui.createIconButton({
+    mui.newIconButton({
         name = "check",
         text = "check_box_outline_blank",
         width = mui.getScaleVal(50),
@@ -239,8 +239,7 @@ function scene:create( event )
         callBack = mui.actionForCheckbox
     })
 
-    --[[--
-    mui.createToggleSwitch({
+    mui.newToggleSwitch({
         name = "switch_demo",
         size = mui.getScaleVal(55),
         x = mui.getScaleVal(360),
@@ -253,9 +252,8 @@ function scene:create( event )
         value = 100, -- if switch is in the on position it's 100 else nil
         callBack = mui.actionForSwitch
     })
-    --]]--
 
-    mui.createRadioGroup({
+    mui.newRadioGroup({
         name = "radio_demo",
         width = mui.getScaleVal(30), --+ (getScaleVal(30)*1.2),
         height = mui.getScaleVal(30),
@@ -274,7 +272,7 @@ function scene:create( event )
     })
 
     ---[[--
-    mui.createTableView({
+    mui.newTableView({
         name = "tableview_demo",
         width = mui.getScaleVal(300),
         height = mui.getScaleVal(300),
@@ -307,7 +305,7 @@ function scene:create( event )
     })
     --]]--
 
-    mui.createTextField({
+    mui.newTextField({
         name = "textfield_demo",
         labelText = "Subject",
         text = "Hello, world!",
@@ -322,7 +320,7 @@ function scene:create( event )
     })
 
     -- create and animate the intial value (1% is always required due to scaling method)
-    mui.createProgressBar({
+    mui.newProgressBar({
         name = "progressbar_demo",
         width = mui.getScaleVal(290),
         height = mui.getScaleVal(8),
@@ -353,7 +351,7 @@ function scene:create( event )
 
     -- on bottom and stay on top of other widgets.
     local buttonHeight = mui.getScaleVal(70)
-    mui.createToolbar({
+    mui.newToolbar({
         name = "toolbar_demo",
         --width = mui.getScaleVal(500), -- defaults to display.contentWidth
         height = mui.getScaleVal(70),

--- a/onboard.lua
+++ b/onboard.lua
@@ -43,7 +43,7 @@ function scene:create( event )
     -- GROUP 1
     --
 
-    local group1 = mui.createParentOnBoard({
+    local group1 = mui.newParentOnBoard({
         name = "group1",
         object = display.newGroup()
     })
@@ -77,7 +77,7 @@ function scene:create( event )
     }
     textWidth = mui.getTextWidth( options )
     options.width = textWidth
-    mui.createBasicText( options )
+    mui.newBasicText( options )
     local introText = mui.getWidgetBaseObject("intro-text")
     introText.x = (background.contentWidth * 0.5)
     group1:insert( introText )
@@ -86,7 +86,7 @@ function scene:create( event )
     -- GROUP 2
     --
 
-    local group2 = mui.createParentOnBoard({
+    local group2 = mui.newParentOnBoard({
         name = "group2",
         object = display.newGroup()
     })
@@ -120,7 +120,7 @@ function scene:create( event )
     }
     textWidth = mui.getTextWidth( options )
     options.width = textWidth
-    mui.createBasicText( options )
+    mui.newBasicText( options )
     local introText2 = mui.getWidgetBaseObject("intro-text2")
     introText2.x = (background2.contentWidth * 0.5)
     group2:insert( introText2 )
@@ -149,7 +149,7 @@ function scene:create( event )
     -- BOTTOM GROUP of Onboarding
     --
 
-    local groupBottom = mui.createParentOnBoard({
+    local groupBottom = mui.newParentOnBoard({
         name = "groupBottom",
         object = display.newGroup()
     })
@@ -167,7 +167,7 @@ function scene:create( event )
     backgroundBottom:setFillColor( unpack( colorFill ) )
     groupBottom:insert( backgroundBottom )
 
-    mui.createIconButton({
+    mui.newIconButton({
         name = "continue-button",
         text = "arrow_forward",
         width = mui.getScaleVal(50),
@@ -191,7 +191,7 @@ function scene:create( event )
     --
     -- Elipses / progress indicator
     --
-    mui.createElipsesForProgress({
+    mui.newElipsesForProgress({
         parent = "groupBottom",
         group = groupBottom,
         slides = 2, -- number of slides


### PR DESCRIPTION
## [0.1.23] - 2016-07-22
### Change
- Put back the toggle switch in the demo.
- Renamed all methods with prefix 'create' to 'new'. Example newDialog() instead of createDialog(). Backwards compability will remain for a while. Any new methods will use 'new' prefix.
- Renamed all methods with prefix 'removeWidget' to 'remove'.  Example removeDialog() instead of removeWidgetDialog(). Backwards compability will remain for a while. Any new methods will use 'remove' prefix.
