### PR TITLE
Added options to init() call 'minPixelScaleWidthForPortrait' and 'min…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.30] - 2016-07-27
+### Added
+- Options to init() call 'minPixelScaleWidthForPortrait' and 'minPixelWidthForLandscape' with init(nil, {minPixelScaleWidthForLandscape=[value],minPixelScaleWidthForLandscape=[value]} to override the base scale of MUI elements (defaults to 640 portrait and 960 landscape).
+
 ## [0.1.29] - 2016-07-26
 ### Added
 - setDisplayToActualDimensions() method. Set the display dimensions to use display.actualContentWidth and height or display.contentWidth and height. If true it uses actual content width and height.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Special Considerations
 * Scroll views must contain the method mui.updateEventHandler( event ) before the check for event began. See fun.lua for an example.
 * Scroll views must contain the method mui.updateUI(event) in "moved" phase. See fun.lua for an example.
 * Navigation bars should be added last so they reside on top of most elements/widgets. This follows Corona SDK.
+* Use 'minPixelScaleWidthForPortrait' and 'minPixelScaleWidthForLandscape' with init(nil, {minPixelScaleWidthForLandscape=[value],minPixelScaleWidthForLandscape=[value]} to override the base scale of MUI elements.
 
 Additional Features
 -------------

--- a/materialui/mui-base.lua
+++ b/materialui/mui-base.lua
@@ -69,6 +69,8 @@ function M.init_base(options)
   muiData.onBoardData = nil
   muiData.slideData = nil
   muiData.currentSlide = 0
+  muiData.minPixelScaleWidthForPortrait = options.minPixelScaleWidthForPortrait or 640
+  muiData.minPixelScaleWidthForLandscape = options.minPixelScaleWidthForLandscape or 960
   options.useActualDimensions = options.useActualDimensions or true
   M.setDisplayToActualDimensions( {useActualDimensions = options.useActualDimensions} )
 
@@ -263,9 +265,9 @@ function M.getSizeRatio()
   end
   local divisor = 1
   if string.find(system.orientation, "portrait") ~= nil then
-    divisor = 640
+    divisor = muiData.minPixelScaleWidthForPortrait
   elseif string.find(system.orientation, "landscape") ~= nil then
-    divisor = 960
+    divisor = muiData.minPixelScaleWidthForLandscape
   end
 
   muiData.masterRatio = muiData.contentWidth / divisor


### PR DESCRIPTION
## [0.1.30] - 2016-07-27
### Added
- Options to init() call 'minPixelScaleWidthForPortrait' and 'minPixelWidthForLandscape' with init(nil, {minPixelScaleWidthForLandscape=[value],minPixelScaleWidthForLandscape=[value]} to override the base scale of MUI elements (defaults to 640 portrait and 960 landscape).
