### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.31] - 2016-07-29
 ### Added
-- getWidget method to get a widgets property. This allows the widget text, icon and layer properties change on the fly.  For example, change the 'alpha' of a rectangle button do: mui.getWidget( 'name of widget', 'layer_1' ).alpha = 0.2 or local obj = mui.getWidget( 'name of widget', 'layer_1' ) and then obj.alpha = 0.2 .  This only works for "buttons" for now other widgets will be available soon.
+- getWidget() method to get a widget's property. This allows the widget text, icon and layer properties change on the fly.  For example, change the 'alpha' of a rectangle button do: mui.getWidget( 'name of widget', 'layer_1' ).alpha = 0.2 or local obj = mui.getWidget( 'name of widget', 'layer_1' ) and then obj.alpha = 0.2 .  This only works for "buttons" for now and other widgets will be available soon.
 
 ## [0.1.30] - 2016-07-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.31] - 2016-07-29
+### Added
+- getWidget method to get a widgets property. This allows the widget text, icon and layer properties change on the fly.  For example, change the 'alpha' of a rectangle button do: mui.getWidget( 'name of widget', 'layer_1' ).alpha = 0.2 or local obj = mui.getWidget( 'name of widget', 'layer_1' ) and then obj.alpha = 0.2 .  This only works for "buttons" for now other widgets will be available soon.
+
 ## [0.1.30] - 2016-07-27
 ### Added
 - Options to init() call 'minPixelScaleWidthForPortrait' and 'minPixelWidthForLandscape' with init(nil, {minPixelScaleWidthForLandscape=[value],minPixelScaleWidthForLandscape=[value]} to override the base scale of MUI elements (defaults to 640 portrait and 960 landscape).

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Helper Methods
 - `attachToRow` - attaches widget to table view row.
 - `closeDialog` - closes an open dialog and releases memory
 - `getScaleVal` - returns integer scaled value to fit resolution. Useful for dimensions and coordinates.
+- `getWidget` - returns the widget property by name. The property can be the text or layer of the widget (like a button).
 - `getWidgetByName` - returns the array of a named widget.
 - `getWidgetBaseObject` - returns the base object of a named widget created with one of the above methods. It can be inserted into another container, group, scrollview and moved around, etc.  Example: rectangle_surface:insert( mui.getWidgetBaseObject("okay_button") )
 - `getEventParameter` - returns the event MUI widget parameters for the current widget.  Get the event target, widget name, widget value ( ex: getEventParameter(event, "muiTargetValue") ).  The value is set when creating a widget.  See menu.lua for setting the values and mui.lua callBacks for getting values (example would be actionForSwitch() method).

--- a/materialui/mui-base.lua
+++ b/materialui/mui-base.lua
@@ -228,6 +228,8 @@ function M.getWidgetBaseObject(name)
                widgetData = muiData.widgetDict[widget]["container"]
             elseif widgetType == "TextBox" then
                widgetData = muiData.widgetDict[widget]["container"]
+            elseif widgetType == "TileGrid" then
+               widgetData = muiData.widgetDict[widget]["mygroup"]
             elseif widgetType == "TimePicker" then
                widgetData = muiData.widgetDict[widget]["mygroup"]
             elseif widgetType == "ProgressBar" then
@@ -247,6 +249,26 @@ function M.getWidgetBaseObject(name)
         end
     end
     return widgetData
+end
+
+function M.getWidget( widgetName, propertyName )
+  local widgetData = nil
+  if widgetName == nil or propertyName == nil then return widgetData end
+
+  if muiData.widgetDict[widgetName]["type"] == "EmbossedText" or muiData.widgetDict[widgetName]["type"] == "Text" then
+    widgetData = M.getTextProperty( widgetName, propertyName )
+  elseif muiData.widgetDict[widgetName]["type"] == "RRectButton" then
+    widgetData = M.getRoundedRectButtonProperty( widgetName, propertyName )
+  elseif muiData.widgetDict[widgetName]["type"] == "RectButton" then
+    widgetData = M.getRectButtonProperty( widgetName, propertyName )
+  elseif muiData.widgetDict[widgetName]["type"] == "IconButton" then
+    widgetData = M.getIconButtonProperty( widgetName, propertyName )
+  elseif muiData.widgetDict[widgetName]["type"] == "CircleButton" then
+    widgetData = M.getCircleButtonProperty( widgetName, propertyName )
+  elseif muiData.widgetDict[widgetName]["type"] == "RadioButton" then
+    widgetData = M.getRadioButtonProperty( widgetName, propertyName )
+  end
+  return widgetData
 end
 
 function M.getWidgetValue(widgetName)
@@ -547,6 +569,8 @@ function M.hideWidget(widgetName, options)
             -- not yet supported
         elseif widgetType == "TableView" then
             muiData.widgetDict[widget]["tableview"].isVisible = showWidget
+        elseif widgetType == "TileGrid" then
+            muiData.widgetDict[widget]["mygroup"].isVisible = showWidget
         elseif widgetType == "TextField" or widgetType == "TextBox" then
             muiData.widgetDict[widget]["container"].isVisible = showWidget
         elseif widgetType == "ProgressBar" or widgetType == "ToggleSwitch" then
@@ -605,6 +629,8 @@ function M.destroy()
             M.removeTextField(widget)
         elseif widgetType == "TextBox" then
             M.removeTextBox(widget)
+        elseif widgetType == "TileGrid" then
+            M.removeTileGrid(widget)
         elseif widgetType == "TimePicker" then
             M.removeTimePicker(widget)
         elseif widgetType == "ProgressBar" then

--- a/materialui/mui-button.lua
+++ b/materialui/mui-button.lua
@@ -189,6 +189,21 @@ function M.newRoundedRectButton(options)
     muiData.widgetDict[options.name]["rrect"]:addEventListener( "touch", M.touchRRectButton )
 end
 
+function M.getRoundedRectButtonProperty(widgetName, propertyName)
+    local data = nil
+
+    if widgetName == nil or propertyName == nil then return data end
+
+    if propertyName == "text" then
+        data = muiData.widgetDict[widgetName]["myText"] -- button text
+    elseif propertyName == "layer_1" then
+        data = muiData.widgetDict[widgetName]["rrect2"] -- button shadow
+    elseif propertyName == "layer_2" then
+        data = muiData.widgetDict[widgetName]["rrect"] -- button face
+    end
+    return data
+end
+
 function M.touchRRectButton (event)
     local options = nil
     if event.target ~= nil then
@@ -395,6 +410,18 @@ function M.newRectButton(options)
     muiData.widgetDict[options.name]["rrect"]:addEventListener( "touch", M.touchRRectButton )
 end
 
+function M.getRectButtonProperty(widgetName, propertyName)
+    local data = nil
+
+    if widgetName == nil or propertyName == nil then return data end
+
+    if propertyName == "text" then
+        data = muiData.widgetDict[widgetName]["myText"] -- button text
+    elseif propertyName == "layer_1" then
+        data = muiData.widgetDict[widgetName]["rrect"] -- button face
+    end
+    return data
+end
 
 --[[
  options..
@@ -527,6 +554,17 @@ function M.newIconButton(options)
 
     checkbox.muiOptions = options
     muiData.widgetDict[options.name]["myText"]:addEventListener( "touch", M.touchIconButton )
+end
+
+function M.getIconButtonProperty(widgetName, propertyName)
+    local data = nil
+
+    if widgetName == nil or propertyName == nil then return data end
+
+    if propertyName == "icon" then
+        data = muiData.widgetDict[widgetName]["myText"] -- button
+    end
+    return data
 end
 
 function M.touchIconButton (event)
@@ -709,6 +747,19 @@ function M.newCircleButton(options)
 
     circle.muiOptions = options
     muiData.widgetDict[options.name]["circlemain"]:addEventListener( "touch", M.touchCircleButton )
+end
+
+function M.getCircleButtonProperty(widgetName, propertyName)
+    local data = nil
+
+    if widgetName == nil or propertyName == nil then return data end
+
+    if propertyName == "text" then
+        data = muiData.widgetDict[widgetName]["myText"] -- button
+    elseif propertyName == "layer_1" then
+        data = muiData.widgetDict[widgetName]["circlemain"] -- the base
+    end
+    return data
 end
 
 function M.touchCircleButton (event)
@@ -945,6 +996,19 @@ function M.newRadioButton(options)
     checkbox.muiOptions = options
     muiData.widgetDict[options.basename]["radio"][options.name]["myText"]:addEventListener( "touch", M.touchCheckbox )
 
+end
+
+function M.getRadioButtonProperty(widgetName, propertyName)
+    local data = nil
+
+    if widgetName == nil or propertyName == nil then return data end
+
+    if propertyName == "text" then
+        data = muiData.widgetDict[widgetName]["myText"] -- button
+    elseif propertyName == "label" then
+        data = muiData.widgetDict[widgetName]["myLabel"] -- the base
+    end
+    return data
 end
 
 function M.touchCheckbox (event)

--- a/materialui/mui-text.lua
+++ b/materialui/mui-text.lua
@@ -55,6 +55,11 @@ function M.newText(options)
     muiData.widgetDict[options.name]["text"]:setFillColor( unpack(options.fillColor) )
 end
 
+function M.getTextProperty(widgetName, property_name)
+    if options == nil then return nil end
+    return muiData.widgetDict[options.name]["text"]
+end
+
 function M.removeWidgetText(widgetName)
     M.removeText(widgetName)
 end
@@ -83,6 +88,10 @@ function M.newEmbossedText(options)
     if options.embossedColor ~= nil then
         muiData.widgetDict[options.name]["text"]:setEmbossColor( options.embossedColor )
     end
+end
+
+function M.getEmbossedTextProperties(options)
+  return M.getTextProperties(options)
 end
 
 function M.removeEmbossedText(widgetName)

--- a/materialui/mui.lua
+++ b/materialui/mui.lua
@@ -56,6 +56,7 @@ local modules = {
   "materialui.mui-tableview",
   "materialui.mui-textinput",
   "materialui.mui-text",
+  --"materialui.mui-tile",
   "materialui.mui-toast",
   "materialui.mui-toolbar"
 }

--- a/menu.lua
+++ b/menu.lua
@@ -105,7 +105,7 @@ function scene:create( event )
     })
 
     mui.newRectButton({
-        name = "scene2",
+        name = "switchSceneButton",
         text = "Switch Scene",
         width = mui.getScaleVal(200),
         height = mui.getScaleVal(60),
@@ -121,6 +121,17 @@ function scene:create( event )
             sceneTransitionColor = { 0, 0.73, 1 }
         } -- scene fun.lua
     })
+
+    -- get widget and change the color of the text
+    local widgetData = mui.getWidget( "switchSceneButton", "text" )
+    if widgetData ~= nil then
+        widgetData:setFillColor( 1, 1 ,1 ,1 )
+    end
+    -- get widget and change the color of the layer that sits beneath text
+    widgetData = mui.getWidget( "switchSceneButton", "layer_1" )
+    if widgetData ~= nil then
+        widgetData:setFillColor( 0.25, 0.75, 1, 1 )
+    end
 
     mui.newIconButton({
         name = "plus",


### PR DESCRIPTION
## [0.1.31] - 2016-07-29
### Added
- getWidget() method to get a widget's property. This allows the widget text, icon and layer properties change on the fly.  For example, change the 'alpha' of a rectangle button do: mui.getWidget( 'name of widget', 'layer_1' ).alpha = 0.2 or local obj = mui.getWidget( 'name of widget', 'layer_1' ) and then obj.alpha = 0.2 .  This only works for "buttons" for now and other widgets will be available soon.
