### PR TITLE
Added newImage and newImageRect support and bug fix for white border …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.37] - 2016-08-15
+### Added
+- support for display.newImage() and display.newImageRect() via wrappers. See mui-image.lua for options. For an example usage see http://www.anedix.com/fileshare/login-form.zip
+- "value" to both newTextField and newTextBox properties. This allows pulling the information later in another method.  Example: local email = mui.getWidgetProperty("textfield_email", "value")
+
+### Change
+- Bug fix for newRoundedRect() method so it won't have the "white" outline on it if gradient shadows are not used.
+- Bug fixes.
+
 ## [0.1.36] - 2016-08-11
 ### Added
 - Image buttons. These can be specified using a single image or two images for on/off states.  See menu.lua and look for "Open Dialog" for an example. See project wiki too https://github.com/arcadefx/material-ui/wiki/Buttons for more information.

--- a/materialui/mui-base.lua
+++ b/materialui/mui-base.lua
@@ -65,7 +65,7 @@ function M.init_base(options)
   muiData.dialogInUse = false
   muiData.dialogName = nil
   muiData.navbarHeight = 0
-  muiData.navbarSupportedTypes = { "Text", "EmbossedText", "CircleButton", "RRectButton", "RectButton", "IconButton", "Slider", "TextField", "Generic" }
+  muiData.navbarSupportedTypes = { "Text", "EmbossedText", "Image", "ImageRect", "CircleButton", "RRectButton", "RectButton", "IconButton", "Slider", "TextField", "Generic" }
   muiData.onBoardData = nil
   muiData.slideData = nil
   muiData.currentSlide = 0
@@ -206,6 +206,10 @@ function M.getWidgetBaseObject(name)
                widgetData = muiData.widgetDict[widget]["text"]
             elseif widgetType == "CircleButton" then
                widgetData = muiData.widgetDict[widget]["mygroup"]
+            elseif widgetType == "Image" then
+               widgetData = muiData.widgetDict[widget]["image"]
+            elseif widgetType == "ImageRect" then
+               widgetData = muiData.widgetDict[widget]["image_rect"]
             elseif widgetType == "DatePicker" then
                widgetData = muiData.widgetDict[widget]["mygroup"]
             elseif widgetType == "EmbossedText" then
@@ -262,6 +266,10 @@ function M.getWidgetProperty( widgetName, propertyName )
     widgetData = M.getDialogProperty( widgetName, propertyName )
   elseif muiData.widgetDict[widgetName]["type"] == "IconButton" then
     widgetData = M.getIconButtonProperty( widgetName, propertyName )
+  elseif muiData.widgetDict[widgetName]["type"] == "Image" then
+    widgetData = M.getImageProperty( widgetName, propertyName )
+  elseif muiData.widgetDict[widgetName]["type"] == "ImageRect" then
+    widgetData = M.getImageRectProperty( widgetName, propertyName )
   elseif muiData.widgetDict[widgetName]["type"] == "NavBar" then
     widgetData = M.getNavBarProperty( widgetName, propertyName )
   elseif muiData.widgetDict[widgetName]["type"] == "ProgressBar" then
@@ -699,6 +707,10 @@ function M.hideWidget(widgetName, options)
             muiData.widgetDict[widget]["circlemain"].isVisible = showWidget
         elseif widgetType == "DatePicker" or widgetType == "TimePicker" then
             muiData.widgetDict[widget]["mygroup"].isVisible = showWidget
+        elseif widgetType == "Image" then
+            muiData.widgetDict[widget]["image"].isVisible = showWidget
+        elseif widgetType == "ImageRect" then
+            muiData.widgetDict[widget]["image_rect"].isVisible = showWidget
         elseif widgetType == "RRectButton" or widgetType == "RectButton" then
             muiData.widgetDict[widget]["container"].isVisible = showWidget
         elseif widgetType == "IconButton" or widgetType == "RadioButton" then
@@ -749,6 +761,10 @@ function M.destroy()
             M.removeCircleButton(widget)
         elseif widgetType == "DatePicker" then
             M.removeDatePicker(widget)
+        elseif widgetType == "Image" then
+            M.removeImage(widget)
+        elseif widgetType == "ImageRect" then
+            M.removeImageRect(widget)
         elseif widgetType == "EmbossedText" then
             M.removeEmbossedText(widget)
         elseif widgetType == "RRectButton" then

--- a/materialui/mui-button.lua
+++ b/materialui/mui-button.lua
@@ -135,6 +135,8 @@ function M.newRoundedRectButton(options)
     muiData.widgetDict[options.name]["rrect2"] = display.newRoundedRect( 0, 1, options.width+M.getScaleVal(8), options.height+M.getScaleVal(8), nr )
     if paint ~= nil then
         muiData.widgetDict[options.name]["rrect2"].fill = paint
+    else
+        muiData.widgetDict[options.name]["rrect2"].isVisible = false
     end
     muiData.widgetDict[options.name]["container"]:insert( muiData.widgetDict[options.name]["rrect2"] )
 
@@ -145,10 +147,6 @@ function M.newRoundedRectButton(options)
 
     if options.strokeWidth == nil then
         options.strokeWidth = 0
-    end
-
-    if options.strokeColor == nil then
-        options.strokeColor = { 0.9, 0.9, 0.9, 1 }
     end
 
     muiData.widgetDict[options.name]["rrect"] = display.newRoundedRect( 0, 0, options.width, options.height, radius )

--- a/materialui/mui-image.lua
+++ b/materialui/mui-image.lua
@@ -1,7 +1,7 @@
 --[[
     A loosely based Material UI module
 
-    mui-text.lua : This is a wrapper for creating text widgets.
+    mui-image.lua : This is a wrapper for creating image widgets.
 
     The MIT License (MIT)
 
@@ -40,69 +40,59 @@ local mathABS = math.abs
 local M = muiData.M -- {} -- for module array/table
 
 -- define methods here
-function M.createText(options)
-    M.newText(options)
-end
-
-function M.newText(options)
+function M.newImage(options)
 	if options == nil then return end
+    if options.image == nil then return end
 
     muiData.widgetDict[options.name] = {}
-    muiData.widgetDict[options.name]["type"] = "Text"
+    muiData.widgetDict[options.name]["type"] = "Image"
     muiData.widgetDict[options.name]["options"] = options
 
-    muiData.widgetDict[options.name]["text"] = display.newText( options )
-    muiData.widgetDict[options.name]["text"]:setFillColor( unpack(options.fillColor) )
+    muiData.widgetDict[options.name]["image"] = display.newImage( options.image )
 end
 
-function M.getTextProperty(widgetName, property_name)
+function M.getImageProperty(widgetName, property_name)
     if options == nil then return nil end
-    return muiData.widgetDict[options.name]["text"]
+    return muiData.widgetDict[options.name]["image"]
 end
 
-function M.removeWidgetText(widgetName)
-    M.removeText(widgetName)
-end
-
-function M.removeText(widgetName)
+function M.removeImage(widgetName)
     if widgetName == nil then
         return
     end
 
     if muiData.widgetDict[widgetName] == nil then return end
 
-    muiData.widgetDict[widgetName]["text"]:removeSelf()
-    muiData.widgetDict[widgetName]["text"] = nil
+    muiData.widgetDict[widgetName]["image"]:removeSelf()
+    muiData.widgetDict[widgetName]["image"] = nil
     muiData.widgetDict[widgetName] = nil
 end
 
-function M.newEmbossedText(options)
+function M.newImageRect(options)
     if options == nil then return end
+    if options.image == nil or options.width == nil or options.height == nil then return end
 
     muiData.widgetDict[options.name] = {}
-    muiData.widgetDict[options.name]["type"] = "EmbossedText"
+    muiData.widgetDict[options.name]["type"] = "ImageRect"
     muiData.widgetDict[options.name]["options"] = options
 
-    muiData.widgetDict[options.name]["text"] = display.newEmbossedText( options )
-    muiData.widgetDict[options.name]["text"]:setFillColor( unpack(options.fillColor) )
-    if options.embossedColor ~= nil then
-        muiData.widgetDict[options.name]["text"]:setEmbossColor( options.embossedColor )
-    end
+    muiData.widgetDict[options.name]["image_rect"] = display.newImageRect( options.image, options.width, options.height )
 end
 
-function M.getEmbossedTextProperties(options)
-  return M.getTextProperties(options)
+function M.getImageRectProperty(widgetName, property_name)
+    if options == nil then return nil end
+    return muiData.widgetDict[options.name]["image_rect"]
 end
 
-function M.removeEmbossedText(widgetName)
+function M.removeImageRect(widgetName)
     if widgetName == nil then
         return
     end
 
     if muiData.widgetDict[widgetName] == nil then return end
 
-    muiData.widgetDict[widgetName]["text"]:removeSelf()
-    muiData.widgetDict[widgetName]["text"] = nil
+    muiData.widgetDict[widgetName]["image_rect"]:removeSelf()
+    muiData.widgetDict[widgetName]["image_rect"] = nil
     muiData.widgetDict[widgetName] = nil
 end
 

--- a/materialui/mui-textinput.lua
+++ b/materialui/mui-textinput.lua
@@ -201,6 +201,8 @@ function M.getTextFieldProperty(widgetName, propertyName)
         data = muiData.widgetDict[widgetName]["rect"] -- clickable area
     elseif propertyName == "layer_2" then
         data = muiData.widgetDict[widgetName]["textfield"] -- native text field
+    elseif propertyName == "value" then
+        data = muiData.widgetDict[widgetName]["textfield"].text -- native text field value
     elseif propertyName == "layer_3" then
         data = muiData.widgetDict[widgetName]["textfieldfake"] -- fake text field
     elseif propertyName == "layer_4" then

--- a/materialui/mui.lua
+++ b/materialui/mui.lua
@@ -46,6 +46,7 @@ local modules = {
   "materialui.mui-button",
   "materialui.mui-datetime",
   "materialui.mui-dialog",
+  "materialui.mui-image",
   "materialui.mui-navbar",
   "materialui.mui-onboarding",
   "materialui.mui-progressbar",


### PR DESCRIPTION
## [0.1.37] - 2016-08-15
### Added
- support for display.newImage() and display.newImageRect() via wrappers. See mui-image.lua for options. For an example usage see http://www.anedix.com/fileshare/login-form.zip
- "value" to both newTextField and newTextBox properties. This allows pulling the information later in another method.  Example: local email = mui.getWidgetProperty("textfield_email", "value")
