### PR TITLE
Added shadow support for buttons and added method newShadowShape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.39] - 2016-08-17
+### Added
+- "newShadowShape()" method -- create a shadow shape for rectangle (rect), rounded rectangle (rounded_rect) and circle (circle).
+- shadow support to newRectButton, newRoundedRectButton and newCircleButton. See wiki https://github.com/arcadefx/material-ui/wiki/Buttons for more information.
+
 ## [0.1.38] - 2016-08-15
 ### Added
 - "value" property to all buttons, user input and such. Use getWidgetProperty() to get the value of the widget.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Please read Lua code to find all parameters and see example in the repo call men
 
 *Buttons*
 
-Buttons can contain image sheets for handling single or multiple images for a button (two states available on/off).  Buttons can also be a single graphic button.  See [Wiki for Buttons](https://github.com/arcadefx/material-ui/wiki/Buttons).  In menu.lua there is an example and it's used to "Open Dialog" in the demo.
+Buttons can contain image sheets for handling single or multiple images for a button (two states available on/off).  Buttons can also be a single graphic button.  See [Wiki for Buttons](https://github.com/arcadefx/material-ui/wiki/Buttons).  In menu.lua there is an example and it's used to "Open Dialog" in the demo.  Shadows can be added as well see wiki for more information.
 
 | Method        | Short Description | Example  |
 | ------------- | ------------- | :-----:|
@@ -146,6 +146,7 @@ Helper Methods
 - `getWidgetBaseObject` - returns the base object of a named widget created with one of the above methods. It can be inserted into another container, group, scrollview and moved around, etc.  Example: rectangle_surface:insert( mui.getWidgetBaseObject("okay_button") )
 - `getEventParameter` - returns the event MUI widget parameters for the current widget.  Get the event target, widget name, widget value ( ex: getEventParameter(event, "muiTargetValue") ).  The value is set when creating a widget.  See menu.lua for setting the values and mui.lua callBacks for getting values (example would be actionForSwitch() method).
 - `hideWidget` - hide a widget by name. It will hide/show a widget by setting the isVisible attribute.
+- `newShadowShape` - create a shadow shape for rectangle (rect), rounded rectangle (rounded_rect) and circle (circle).
 - `setDisplayToActualDimensions` - Set the display dimensions to use display.actualContentWidth and height or display.contentWidth and height.  Apply this when calling muiData.init(...), example: muiData.init( nil, {useActualDimensions = true} ).
 
 Remove widget methods - these will remove the widget by name and release memory:

--- a/materialui/mui-base.lua
+++ b/materialui/mui-base.lua
@@ -432,6 +432,52 @@ function M.transitionColor(displayObj, params)
   end
 end
 
+--
+-- options: style, width, height, offsetX, offsetY, size, cornerRadius, opacity
+--
+function M.newShadowShape( shape, options )
+  local g = display.newGroup()
+  g.x, g.y = display.contentCenterX, display.contentCenterY
+
+  local style = options.style or "filter.blurGaussian"
+  local width, height = options.width, options.height
+  local offsetX, offsetY = (options.offsetX or 0), (options.offsetY or 0)
+  local size = options.size
+  local cornerRadius = options.cornerRadius or 5
+  local opacity = options.opacity
+
+  if shape == "rect" then
+    display.newRect( g, offsetX, offsetY, width+size, height+size ).fill = {1,1,1,0}
+    display.newRect( g, offsetX, offsetY, width, height ).fill = {0,0,0}
+  elseif shape == "rounded_rect" then
+    display.newRoundedRect( g, offsetX, offsetY, width+size, height+size, cornerRadius ).fill = {1,1,1,0}
+    display.newRoundedRect( g, offsetX, offsetY, width, height, cornerRadius ).fill = {0,0,0}
+  elseif shape == "circle" then
+    local radius = width * 0.5
+    display.newCircle( g, offsetX, offsetY, radius * 1.5 ).fill = {1,1,1,0}
+    display.newCircle( g, offsetX, offsetY, radius ).fill = {0,0,0}
+  end
+
+  local c = display.capture( g )
+  g = display.remove( g )
+
+  c.fill.effect = style
+  if style == "filter.blurGaussian" then
+    c.fill.effect.horizontal.blurSize = size
+    c.fill.effect.horizontal.sigma = size
+    c.fill.effect.vertical.blurSize = size
+    c.fill.effect.vertical.sigma = size
+  elseif style == "filter.linearWipe" then
+    c.fill.effect.direction = { 1, 1 }
+    c.fill.effect.smoothness = 1
+    c.fill.effect.progress = 0.5
+  end
+
+  c.alpha = opacity or 0.3
+
+  return c
+end
+
 function M.split(str, sep)
    local result = {}
    local regex = ("([^%s]+)"):format(sep)

--- a/materialui/mui-button.lua
+++ b/materialui/mui-button.lua
@@ -102,7 +102,12 @@ function M.newRoundedRectButton(options)
     muiData.widgetDict[options.name] = {}
     muiData.widgetDict[options.name]["type"] = "RRectButton"
     -- muiData.widgetDict[options.name]["container"] = display.newGroup() --display.newContainer( nw, nh )
-    muiData.widgetDict[options.name]["container"] = display.newContainer( nw, nh )
+
+    local padding = 0
+    if options.useShadow == true then padding = M.getScaleVal(50) end
+
+    muiData.widgetDict[options.name]["container"] = display.newContainer( nw+padding, nh+padding )
+
     muiData.widgetDict[options.name]["container"]:translate( x, y ) -- center the container
     muiData.widgetDict[options.name]["touching"] = false
 
@@ -114,6 +119,20 @@ function M.newRoundedRectButton(options)
     local radius = options.height * 0.2
     if options.radius ~= nil and options.radius < options.height and options.radius > 1 then
         radius = options.radius
+    end
+
+    if options.useShadow == true then
+        local size = options.shadowSize or M.getScaleVal(20)
+        local opacity = options.shadowOpacity or 0.3
+        local shadow = M.newShadowShape("rounded_rect", {
+            width = options.width,
+            height = options.height,
+            size = size,
+            opacity = opacity,
+            cornerRadius = radius,
+        })
+        muiData.widgetDict[options.name]["shadow"] = shadow
+        muiData.widgetDict[options.name]["container"]:insert( shadow )
     end
 
     local nr = radius + M.getScaleVal(8) -- (options.height+M.getScaleVal(8)) * 0.2
@@ -379,9 +398,12 @@ function M.newRectButton(options)
         y = options.y
     end
 
+    local padding = M.getScaleVal(4)
+    if options.useShadow == true then padding = M.getScaleVal(50) end
+
     muiData.widgetDict[options.name] = {}
     muiData.widgetDict[options.name]["type"] = "RectButton"
-    muiData.widgetDict[options.name]["container"] = display.newContainer( options.width+4, options.height+4 )
+    muiData.widgetDict[options.name]["container"] = display.newContainer( options.width+padding, options.height+padding )
     muiData.widgetDict[options.name]["container"]:translate( x, y ) -- center the container
     muiData.widgetDict[options.name]["touching"] = false
 
@@ -411,6 +433,19 @@ function M.newRectButton(options)
 
     local strokeWidth = 0
     if paint ~= nil then strokeWidth = 1 end
+
+    if options.useShadow == true then
+        local size = options.shadowSize or M.getScaleVal(20)
+        local opacity = options.shadowOpacity or 0.3
+        local shadow = M.newShadowShape("rect", {
+            width = options.width,
+            height = options.height,
+            size = size,
+            opacity = opacity,
+        })
+        muiData.widgetDict[options.name]["shadow"] = shadow
+        muiData.widgetDict[options.name]["container"]:insert( shadow )
+    end
 
     muiData.widgetDict[options.name]["rrect"] = display.newRect( 0, 0, options.width, options.height )
     if paint ~= nil then
@@ -779,6 +814,19 @@ function M.newCircleButton(options)
     muiData.widgetDict[options.name]["font"] = font
     muiData.widgetDict[options.name]["fontSize"] = fontSize
     muiData.widgetDict[options.name]["textMargin"] = textMargin
+
+    if options.useShadow == true then
+        local size = options.shadowSize or M.getScaleVal(options.radius * 0.55)
+        local opacity = options.shadowOpacity or 0.4
+        local shadow = M.newShadowShape("circle", {
+            width = options.radius,
+            height = options.radius,
+            size = size,
+            opacity = opacity,
+        })
+        muiData.widgetDict[options.name]["shadow"] = shadow
+        muiData.widgetDict[options.name]["mygroup"]:insert( shadow )
+    end
 
     -- scale font
     -- Calculate a font size that will best fit the given text field's height
@@ -1328,6 +1376,11 @@ function M.removeRoundedRectButton(widgetName)
         muiData.widgetDict[widgetName]["myImageSheet"] = nil
     end
 
+    if muiData.widgetDict[widgetName]["shadow"] ~= nil then
+        muiData.widgetDict[widgetName]["shadow"]:removeSelf()
+        muiData.widgetDict[widgetName]["shadow"] = nil
+    end
+
     muiData.widgetDict[widgetName]["rrect"]:removeSelf()
     muiData.widgetDict[widgetName]["rrect"] = nil
     muiData.widgetDict[widgetName]["rrect2"]:removeSelf()
@@ -1366,6 +1419,12 @@ function M.removeRectButton(widgetName)
     if muiData.widgetDict[widgetName]["myImageSheet"] ~= nil then
         muiData.widgetDict[widgetName]["myImageSheet"] = nil
     end
+
+    if muiData.widgetDict[widgetName]["shadow"] ~= nil then
+        muiData.widgetDict[widgetName]["shadow"]:removeSelf()
+        muiData.widgetDict[widgetName]["shadow"] = nil
+    end
+
     muiData.widgetDict[widgetName]["rrect"]:removeSelf()
     muiData.widgetDict[widgetName]["rrect"] = nil
     muiData.widgetDict[widgetName]["container"]:removeSelf()
@@ -1402,6 +1461,12 @@ function M.removeCircleButton(widgetName)
     if muiData.widgetDict[widgetName]["myImageSheet"] ~= nil then
         muiData.widgetDict[widgetName]["myImageSheet"] = nil
     end
+
+    if muiData.widgetDict[widgetName]["shadow"] ~= nil then
+        muiData.widgetDict[widgetName]["shadow"]:removeSelf()
+        muiData.widgetDict[widgetName]["shadow"] = nil
+    end
+
     muiData.widgetDict[widgetName]["circlemain"]:removeSelf()
     muiData.widgetDict[widgetName]["circlemain"] = nil
     muiData.widgetDict[widgetName]["mygroup"]:removeSelf()


### PR DESCRIPTION
## [0.1.39] - 2016-08-17
### Added
- "newShadowShape()" method -- create a shadow shape for rectangle (rect), rounded rectangle (rounded_rect) and circle (circle).
- shadow support to newRectButton, newRoundedRectButton and newCircleButton. See wiki https://github.com/arcadefx/material-ui/wiki/Buttons for more information.
