### PR TITLE
Refactored shadows for buttons, cards, shadow shapes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.48] - 2016-10-19
+### Changes
+- Refactored shadows for buttons, cards, shadow shapes.  newShadowShape() has been refactored. Added system event to handle re-creating the opengl textures that make up the shadows per widget. This is run automatically on device resume.
+
 ## [0.1.47] - 2016-10-14
 ### Changes
 - 'arcX' and 'arcY' removed from newProgressArc(..) as parameters.  Instead uses 'x' and 'y' for corrdinates.

--- a/materialui/mui-button.lua
+++ b/materialui/mui-button.lua
@@ -841,6 +841,7 @@ function M.newCircleButton(options)
         local size = options.shadowSize or M.getScaleVal(options.radius * 0.55)
         local opacity = options.shadowOpacity or 0.4
         local shadow = M.newShadowShape("circle", {
+            name = options.name,
             width = options.radius,
             height = options.radius,
             size = size,
@@ -1406,6 +1407,11 @@ function M.removeRoundedRectButton(widgetName)
     end
 
     if muiData.widgetDict[widgetName]["shadow"] ~= nil then
+        if muiData.shadowShapeDict[widgetName] ~= nil then
+            muiData.shadowShapeDict[widgetName]["snapshot"]:removeSelf()
+            muiData.shadowShapeDict[widgetName]["snapshot"] = nil
+            muiData.shadowShapeDict[widgetName] = nil
+        end
         muiData.widgetDict[widgetName]["shadow"]:removeSelf()
         muiData.widgetDict[widgetName]["shadow"] = nil
     end
@@ -1450,6 +1456,11 @@ function M.removeRectButton(widgetName)
     end
 
     if muiData.widgetDict[widgetName]["shadow"] ~= nil then
+        if muiData.shadowShapeDict[widgetName] ~= nil then
+            muiData.shadowShapeDict[widgetName]["snapshot"]:removeSelf()
+            muiData.shadowShapeDict[widgetName]["snapshot"] = nil
+            muiData.shadowShapeDict[widgetName] = nil
+        end
         muiData.widgetDict[widgetName]["shadow"]:removeSelf()
         muiData.widgetDict[widgetName]["shadow"] = nil
     end
@@ -1492,6 +1503,11 @@ function M.removeCircleButton(widgetName)
     end
 
     if muiData.widgetDict[widgetName]["shadow"] ~= nil then
+        if muiData.shadowShapeDict[widgetName] ~= nil then
+            muiData.shadowShapeDict[widgetName]["snapshot"]:removeSelf()
+            muiData.shadowShapeDict[widgetName]["snapshot"] = nil
+            muiData.shadowShapeDict[widgetName] = nil
+        end
         muiData.widgetDict[widgetName]["shadow"]:removeSelf()
         muiData.widgetDict[widgetName]["shadow"] = nil
     end

--- a/materialui/mui-card.lua
+++ b/materialui/mui-card.lua
@@ -101,6 +101,7 @@ function M.newCard(options)
         muiData.widgetDict[options.name]["rect"] = display.newRect( 0, 0, options.width, options.height)
         if options.useShadow == true then
             local shadow = M.newShadowShape("rect", {
+                name = options.name,
                 width = options.width,
                 height = options.height,
                 size = options.shadowSize,
@@ -113,6 +114,7 @@ function M.newCard(options)
         muiData.widgetDict[options.name]["rect"] = display.newRoundedRect( 0, 0, options.width, options.height - nr, nr)
         if options.useShadow == true then
             local shadow = M.newShadowShape("rounded_rect", {
+                name = options.name,
                 width = options.width,
                 height = options.height,
                 size = options.shadowSize,
@@ -266,6 +268,11 @@ function M.removeCard(widgetName)
         muiData.widgetDict[widgetName]["rectTop"] = nil
     end
     if muiData.widgetDict[widgetName]["shadow"] ~= nil then
+        if muiData.shadowShapeDict[widgetName] ~= nil then
+            muiData.shadowShapeDict[widgetName]["snapshot"]:removeSelf()
+            muiData.shadowShapeDict[widgetName]["snapshot"] = nil
+            muiData.shadowShapeDict[widgetName] = nil
+        end
         muiData.widgetDict[widgetName]["shadow"]:removeSelf()
         muiData.widgetDict[widgetName]["shadow"] = nil
     end


### PR DESCRIPTION
## [0.1.48] - 2016-10-19
### Changes
- Refactored shadows for buttons, cards, shadow shapes.  newShadowShape() has been refactored. Added system event to handle re-creating the opengl textures that make up the shadows per widget. This is run automatically on device resume.
