### PR TITLE
added newSnackBar(..) method with action button and fixed 'parent' ob…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.50] - 2017-01-08
+### Added
+- Method "newSnackBar" for creating snack bar and action button text. These flow up from the bottom.  Like "Removed Msgs  UNDO" and it times out after 3 seconds.  Use "timeOut" to specify timeout in microseconds.
+
+### Change
+- Fixed all "parent" group/scene paramater for all controls.  The demo is updated using a parent for all buttons.  Click "coffee cup" to see all the controls slide up (snack bar).
+
 ## [0.1.49] - 2017-01-06
 ### Changes
 - Added "useTimeOut" parameter to newToast(..) method.  useTimeOut is boolean.  This is used to automatically timeout and close the toast notification.  If not "timeOut" in microseconds is specified it defaults to 2000 or 2 seconds.
 - Added "timeOut" parameter to newToast(..) method.  timeOut is in microseconds.  This is used to automatically timeout and close the toast notification.
-
 
 ## [0.1.48] - 2016-10-19
 ### Changes

--- a/materialui/mui-base.lua
+++ b/materialui/mui-base.lua
@@ -74,6 +74,8 @@ function M.init_base(options)
   muiData.M = M -- all modules need access to parent methods
   muiData.environment = system.getInfo("environment")
   muiData.value = options
+  muiData.group = options.group
+  muiData.parent = options.parent
   muiData.circleSceneSwitch = nil
   muiData.circleSceneSwitchComplete = false
   muiData.touching = false
@@ -280,6 +282,8 @@ function M.getWidgetBaseObject(name)
                widgetData = muiData.widgetDict[widget]["mygroup"]
             elseif widgetType == "Slider" then
                widgetData = muiData.widgetDict[widget]["container"]
+            elseif widgetType == "SnackBar" then
+               widgetData = muiData.widgetDict[widget]["container"]
             elseif widgetType == "Toast" then
                widgetData = muiData.widgetDict[widget]["container"]
             end
@@ -327,6 +331,8 @@ function M.getWidgetProperty( widgetName, propertyName )
     widgetData = M.getSliderProperty( widgetName, propertyName )
   elseif muiData.widgetDict[widgetName]["type"] == "SlidePanel" then
     widgetData = M.getSlidePanelProperty( widgetName, propertyName )
+  elseif muiData.widgetDict[widgetName]["type"] == "SnackBar" then
+    widgetData = M.getSnackBarProperty( widgetName, propertyName )
   elseif muiData.widgetDict[widgetName]["type"] == "EmbossedText" or muiData.widgetDict[widgetName]["type"] == "Text" then
     widgetData = M.getTextProperty( widgetName, propertyName )
   elseif muiData.widgetDict[widgetName]["type"] == "TableView" then
@@ -875,7 +881,7 @@ function M.hideWidget(widgetName, options)
         elseif widgetType == "Slider" then
             muiData.widgetDict[widget]["sliderrect"].isVisible = showWidget
             muiData.widgetDict[widget]["container"].isVisible = showWidget
-        elseif widgetType == "Toast" or widgetType == "Selector" then
+        elseif widgetType == "Toast" or widgetType == "Selector" or widgetType == "SnackBar" then
             muiData.widgetDict[widget]["container"].isVisible = showWidget
         end
       end
@@ -1002,6 +1008,8 @@ function M.destroy()
             M.removeSlidePanel(widget)
         elseif widgetType == "Slider" then
             M.removeSlider(widget)
+        elseif widgetType == "SnackBar" then
+            M.removeSnackBar(widget)
         elseif widgetType == "Toast" then
             M.removeToast(widget)
         elseif widgetType == "Selector" then

--- a/materialui/mui-button.lua
+++ b/materialui/mui-button.lua
@@ -1038,8 +1038,8 @@ function M.newRadioButton(options)
     end
 
     if options.parent ~= nil then
-        muiData.widgetDict[options.name]["parent"] = options.parent
-        muiData.widgetDict[options.name]["parent"]:insert( muiData.widgetDict[options.name]["mygroup"] )
+        radioButton["parent"] = options.parent
+        radioButton["parent"]:insert( radioButton["mygroup"] )
     end
 
     local radius = options.height * 0.2
@@ -1274,6 +1274,7 @@ function M.newRadioGroup(options)
         muiData.widgetDict[options.name]["type"] = "RadioGroup"
         for i, v in ipairs(options.list) do            
             M.newRadioButton({
+                parent = options.parent,
                 name = options.name .. "_" .. i,
                 basename = options.name,
                 label = v.key,

--- a/materialui/mui-snackbar.lua
+++ b/materialui/mui-snackbar.lua
@@ -1,0 +1,352 @@
+--[[
+    A loosely based Material UI module
+
+    mui-snackbar.lua : This is for creating "snackbar" notifications.
+
+    The MIT License (MIT)
+
+    Copyright (C) 2017 Anedix Technologies, Inc.  All Rights Reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    For other software and binaries included in this module see their licenses.
+    The license and the software must remain in full when copying or distributing.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
+--]]--
+
+-- corona
+local widget = require( "widget" )
+local composer = require( "composer" )
+
+-- mui
+local muiData = require( "materialui.mui-data" )
+
+local mathFloor = math.floor
+local mathMod = math.fmod
+local mathABS = math.abs
+
+local M = muiData.M -- {} -- for module array/table
+
+function M.removeSnackBarNow( event )
+    local options = nil
+    local params = event.source.params
+
+    if params.name ~= nil and muiData.widgetDict[params.name]["removeInProgress"] == false then
+        local options = muiData.widgetDict[params.name]["options"]
+        muiData.widgetDict[params.name]["removeInProgress"] = true
+
+        if muiData.interceptMoved == false then
+            if options.easingOut == nil then
+                options.easingOut = 500
+            end
+            muiData.widgetDict[options.name]["container"].name = options.name
+            event.target = muiData.widgetDict[options.name]["rrect"]
+            event.callBackData = options.callBackData
+
+            M.setEventParameter(event, "muiTargetValue", options.value)
+            M.setEventParameter(event, "muiTarget", muiData.widgetDict[options.name]["rrect"])
+
+            if params.touched ~= nil and params.touched == true then
+                assert( options.callBack )(event)
+            end
+            M.moveSnackBarParentView(options.name, "down")
+        end
+    end
+end
+
+function M.createSnackBar( options )
+    M.newSnackBar( options )
+end
+
+function M.newSnackBar( options )
+    if options == nil then return end
+
+    if muiData.widgetDict[options.name] ~= nil then return end
+
+    if options.width == nil then
+        options.width = M.getScaleVal(200)
+    end
+
+    if options.height == nil then
+        options.height = M.getScaleVal(4)
+    end
+
+    if options.radius == nil then
+        options.radius = M.getScaleVal(15)
+    end
+
+    local left,bottom = (muiData.contentWidth-options.width) * 0.5, muiData.contentHeight * 0.5
+    if options.left ~= nil then
+        left = options.left
+    end
+
+    if options.textColor == nil then
+        options.textColor = { 1, 1, 1, 1 }
+    end
+
+    if options.fillColor == nil then
+        options.fillColor = { 0.06, 0.56, 0.15, 1 }
+    end
+
+    if options.font == nil then
+        options.font = native.systemFont
+    end
+
+    if options.bottom == nil then
+        options.bottom = M.getScaleVal(80)
+    end
+
+    if options.useTimeOut == nil then
+        options.useTimeOut = true
+    end
+
+    if options.timeOut == nil then
+        options.timeOut = 2000 -- microseconds, 2 seconds
+    end
+
+    muiData.widgetDict[options.name] = {}
+    muiData.widgetDict[options.name]["type"] = "SnackBar"
+    muiData.widgetDict[options.name]["removeInProgress"] = false
+
+    -- determine if there is a toolbar along the bottom, if so handle the offset of Y position
+    local yOffset = 0
+    local widgetType = nil
+    local widgetLayout = nil
+    for widget in pairs(muiData.widgetDict) do
+        widgetType = muiData.widgetDict[widget]["type"]
+        widgetLayout = muiData.widgetDict[widget]["layout"]
+        if widgetType ~= nil and widgetLayout ~= nil and widgetType == "Toolbar" and widgetLayout == "horizontal" then
+            yOffset = M.getToolBarButtonProperty(widget, "buttonHeight", 1)
+            local ty = muiData.widgetDict[widget]["y_position"]
+            if ty ~= nil then
+                local percent = (ty / muiData.contentHeight)
+                if percent <= 0.89 then
+                    yOffset = 0
+                end
+            end
+            local object = M.getToolBarProperty(widget, "object")
+            if object ~= nil then
+                -- todo: make toolbar grouped!
+            end
+            break
+        end
+    end
+
+    muiData.widgetDict[options.name]["container"] = widget.newScrollView(
+        {
+            top = muiData.contentHeight - yOffset,
+            left = left,
+            width = options.width + (options.width * 0.10),
+            height = options.height + (options.height * 0.10),
+            scrollWidth = options.width,
+            scrollHeight = options.height,
+            hideBackground = true,
+            hideScrollBar = true,
+            isLocked = true
+        }
+    )
+    muiData.widgetDict[options.name]["container"].isVisible = true
+
+    if options.parent ~= nil then
+        muiData.widgetDict[options.name]["parent"] = options.parent
+        muiData.widgetDict[options.name]["parent"]:insert( muiData.widgetDict[options.name]["container"] )
+        M.moveSnackBarParentView(options.name, "up")
+    end
+
+    muiData.widgetDict[options.name]["touching"] = false
+
+    local radius = options.height * 0.2
+    if options.radius ~= nil and options.radius < options.height and options.radius > 1 then
+        radius = options.radius
+    end
+
+    local newX = muiData.widgetDict[options.name]["container"].contentWidth * 0.5
+    local newY = muiData.widgetDict[options.name]["container"].contentHeight * 0.5
+
+    muiData.widgetDict[options.name]["rrect"] = display.newRoundedRect( newX, newY, options.width, options.height, radius )
+    muiData.widgetDict[options.name]["rrect"]:setFillColor( unpack(options.fillColor) )
+    muiData.widgetDict[options.name]["container"]:insert( muiData.widgetDict[options.name]["rrect"] )
+
+    local rrect = muiData.widgetDict[options.name]["rrect"]
+
+    local fontSize = 24
+    if options.fontSize ~= nil then
+        fontSize = options.fontSize
+    end
+
+    local font = native.systemFont
+    if options.font ~= nil then
+        font = options.font
+    end
+
+    muiData.widgetDict[options.name]["font"] = font
+    muiData.widgetDict[options.name]["fontSize"] = fontSize
+
+    local options_for_text = 
+    {
+        text = options.text,
+        x = 0,
+        y = newY,
+        font = font or native.systemFontBold,
+        fontSize = fontSize
+    }
+    muiData.widgetDict[options.name]["myText"] = display.newText( options_for_text )
+    local newTextX = (muiData.widgetDict[options.name]["myText"].contentWidth * 0.5) + M.getScaleVal(20)
+    muiData.widgetDict[options.name]["myText"].x = newTextX
+    muiData.widgetDict[options.name]["myText"]:setFillColor( unpack(options.textColor) )
+    muiData.widgetDict[options.name]["container"]:insert( muiData.widgetDict[options.name]["myText"], true )
+
+    options.buttonText = options.buttonText or "UNDO"
+    options_for_text = 
+    {
+        text = options.buttonText,
+        x = 0,
+        y = newY,
+        font = buttonFont,
+        fontSize = fontSize
+    }
+    muiData.widgetDict[options.name]["myTextButton"] = display.newText( options_for_text )
+    local newTextX = mathABS(options.width - (muiData.widgetDict[options.name]["myTextButton"].contentWidth * 0.5))
+    muiData.widgetDict[options.name]["myTextButton"].x = newTextX
+    options.buttonTextColor = options.buttonTextColor or { 1, 0.23, 0.5, 1 }
+    muiData.widgetDict[options.name]["myTextButton"]:setFillColor( unpack(options.buttonTextColor) )
+    muiData.widgetDict[options.name]["container"]:insert( muiData.widgetDict[options.name]["myTextButton"], true )
+
+    function rrect:touch (event)
+        if muiData.dialogInUse == true and options.dialogName == nil then return end
+
+        if muiData.widgetDict[options.name]["removeInProgress"] == true then return end
+
+        M.addBaseEventParameters(event, options)
+
+        if ( event.phase == "began" ) then
+            if options.useTimeOut == true and muiData.widgetDict[options.name]["removeTimer"] ~= nil then
+                timer.cancel( muiData.widgetDict[options.name]["removeTimer"] )
+                muiData.widgetDict[options.name]["removeTimer"] = nil
+            end
+            --event.target:takeFocus(event)
+            -- if scrollView then use the below
+            muiData.interceptEventHandler = rrect
+            M.updateUI(event)
+            if muiData.touching == false then
+                muiData.touching = true
+            end
+        elseif ( event.phase == "ended" ) then
+            if muiData.widgetDict[options.name]["removeInProgress"] == true then return end
+            if M.isTouchPointOutOfRange( event ) then
+                  event.phase = "offTarget"
+                  -- print("Its out of the button area")
+                  -- event.target:dispatchEvent(event)
+            else
+                event.phase = "onTarget"
+                if muiData.interceptMoved == false then
+                    if options.easingOut == nil then
+                        options.easingOut = 500
+                    end
+                    muiData.widgetDict[options.name]["container"].name = options.name
+                    event.source = {}
+                    event.source.params = { name = options.name, touched = true }
+                    M.removeSnackBarNow(event)
+                end
+            end
+            muiData.interceptEventHandler = nil
+            muiData.interceptMoved = false
+            muiData.touching = false
+        end
+    end
+    muiData.widgetDict[options.name]["rrect"]:addEventListener( "touch", muiData.widgetDict[options.name]["rrect"] )
+
+    if options.easingIn == nil then
+        options.easingIn = 500
+    end
+    transition.to(muiData.widgetDict[options.name]["container"],{time=options.easingIn, y=options.top, transition=easing.inOutCubic})
+    muiData.widgetDict[options.name]["options"] = options
+
+    if options.useTimeOut == true then
+        muiData.widgetDict[options.name]["removeTimer"] = timer.performWithDelay(options.timeOut + options.easingIn, M.removeSnackBarNow, 1)
+        muiData.widgetDict[options.name]["removeTimer"].params = { name = options.name }
+    end
+
+end
+
+function M.moveSnackBarParentView(widgetName, position)
+    local newY = 0
+    if position == "up" then
+        newY = muiData.widgetDict[widgetName]["parent"].y - muiData.widgetDict[widgetName]["container"].contentHeight
+        transition.moveTo(muiData.widgetDict[widgetName]["parent"], {y=newY,time=500})
+    else
+        newY = muiData.widgetDict[widgetName]["parent"].y + muiData.widgetDict[widgetName]["container"].contentHeight
+        muiData.widgetDict[widgetName]["parent"].name = widgetName
+        transition.moveTo(muiData.widgetDict[widgetName]["parent"], {y=newY,time=500,onComplete=M.removeMySnackBar})
+    end
+end
+
+function M.getSnackBarProperty(widgetName, propertyName)
+    local data = nil
+
+    if widgetName == nil or propertyName == nil then return data end
+
+    if propertyName == "object" then
+        data = muiData.widgetDict[widgetName]["container"] -- x,y movement
+    elseif propertyName == "text" then
+        data = muiData.widgetDict[widgetName]["myText"] -- button text
+    elseif propertyName == "layer_1" then
+        data = muiData.widgetDict[widgetName]["rrect"] -- button face
+    end
+    return data
+end
+
+function M.removeMySnackBar(event)
+    local muiName = event.name
+    if muiName ~= nil then
+        M.removeSnackBar(muiName)
+    end
+end
+
+function M.removeWidgetSnackBar(widgetName)
+    M.removeSnackBar(widgetName)
+end
+
+function M.removeSnackBar(widgetName)
+    if widgetName == nil then
+        return
+    end
+
+    if muiData.widgetDict[widgetName] == nil then return end
+
+    local options = muiData.widgetDict[widgetName]["options"]
+    if options.useTimeOut == true and muiData.widgetDict[widgetName]["removeTimer"] ~= nil then
+        timer.cancel( muiData.widgetDict[widgetName]["removeTimer"] )
+        muiData.widgetDict[widgetName]["removeTimer"] = nil
+    end
+
+    muiData.widgetDict[widgetName]["rrect"]:removeEventListener("touch", muiData.widgetDict[widgetName]["sliderrect"])
+    muiData.widgetDict[widgetName]["myTextButton"]:removeSelf()
+    muiData.widgetDict[widgetName]["myTextButton"] = nil    
+    muiData.widgetDict[widgetName]["myText"]:removeSelf()
+    muiData.widgetDict[widgetName]["myText"] = nil
+    muiData.widgetDict[widgetName]["rrect"]:removeSelf()
+    muiData.widgetDict[widgetName]["rrect"] = nil
+    muiData.widgetDict[widgetName]["container"]:removeSelf()
+    muiData.widgetDict[widgetName]["container"] = nil
+    muiData.widgetDict[widgetName]["removeInProgress"] = false
+    muiData.widgetDict[widgetName] = nil
+end
+
+return M

--- a/materialui/mui-tableview.lua
+++ b/materialui/mui-tableview.lua
@@ -110,7 +110,7 @@ function M.newTableView( options )
 
     if options.parent ~= nil then
         muiData.widgetDict[options.name]["parent"] = options.parent
-        muiData.widgetDict[options.name]["parent"]:insert( muiData.widgetDict[options.name]["tableView"] )
+        muiData.widgetDict[options.name]["parent"]:insert( tableView )
     end
 
     -- Insert the row data

--- a/materialui/mui-toolbar.lua
+++ b/materialui/mui-toolbar.lua
@@ -77,6 +77,11 @@ function M.newToolbarButton( options )
     button["mygroup"].y = y
     button["touching"] = false
 
+    if options.parent ~= nil and false then
+        button["parent"] = options.parent
+        button["parent"]:insert( button["mygroup"] )
+    end
+
     -- label colors
     if options.labelColorOff == nil then
         options.labelColorOff = { 0, 0, 0 }
@@ -261,6 +266,10 @@ function M.getToolBarButtonProperty(widgetParentName, propertyName, index)
 
     if propertyName == "object" then
         data = muiData.widgetDict[widgetParentName]["toolbar"][widgetName]["mygroup"] -- x,y movement
+    elseif propertyName == "buttonHeight" then
+        data = muiData.widgetDict[widgetParentName]["toolbar"][widgetName]["buttonHeight"]
+    elseif propertyName == "buttonWidth" then
+        data = muiData.widgetDict[widgetParentName]["toolbar"][widgetName]["buttonWidth"]
     elseif propertyName == "layer_1" then
         data = muiData.widgetDict[widgetParentName]["toolbar"][widgetName]["rectangle"] -- button background
     elseif propertyName == "text" then
@@ -357,8 +366,14 @@ function M.newToolbar( options )
         muiData.widgetDict[options.name] = {}
         muiData.widgetDict[options.name]["toolbar"] = {}
         muiData.widgetDict[options.name]["type"] = "Toolbar"
-        for i, v in ipairs(options.list) do            
+        muiData.widgetDict[options.name]["layout"] = options.layout
+        if muiData.widgetDict[options.name]["layout"] == "horizontal" then
+            muiData.widgetDict[options.name]["y_position"] = y
+            print("height is "..muiData.contentHeight)
+        end
+        for i, v in ipairs(options.list) do
             M.newToolbarButton({
+                parent = options.parent,
                 index = i,
                 name = options.name .. "_" .. i,
                 basename = options.name,

--- a/materialui/mui.lua
+++ b/materialui/mui.lua
@@ -58,6 +58,7 @@ local modules = {
   "materialui.mui-shapes",
   "materialui.mui-slider",
   "materialui.mui-slidepanel",
+  "materialui.mui-snackbar",
   "materialui.mui-switch",
   "materialui.mui-tableview",
   "materialui.mui-textinput",

--- a/menu.lua
+++ b/menu.lua
@@ -11,6 +11,9 @@ local scene = composer.newScene()
 local background = nil
 local widget = require( "widget" )
 
+-- mui
+local muiData = require( "materialui.mui-data" )
+
 -- -----------------------------------------------------------------------------------------------------------------
 -- All code outside of the listener functions will only be executed ONCE unless "composer.removeScene()" is called
 -- -----------------------------------------------------------------------------------------------------------------
@@ -40,7 +43,7 @@ function scene:create( event )
 
     sceneGroup:insert( background )
 
-    mui.init()
+    mui.init(nil, { parent=self.view })
 
     -- dialog box example
     -- use mui.getWidgetBaseObject("dialog_demo") to get surface to add more content
@@ -114,6 +117,7 @@ function scene:create( event )
     -- below is a rounded button with static image with two states (off/on)
     -- tap or click and "hold" to see shadow and release to see it fade to original image
     mui.newRoundedRectButton({
+        parent = muiData.parent,
         name = "newDialog",
         text = "Open Dialog",
         width = mui.getScaleVal(300),
@@ -153,6 +157,7 @@ function scene:create( event )
     })
 
     mui.newRectButton({
+        parent = muiData.parent,
         name = "switchSceneButton",
         text = "Switch Scene",
         width = mui.getScaleVal(200),
@@ -182,6 +187,7 @@ function scene:create( event )
     end
 
     mui.newIconButton({
+        parent = muiData.parent,
         name = "plus",
         text = "help",
         width = mui.getScaleVal(50),
@@ -201,6 +207,7 @@ function scene:create( event )
     -- date picker example
     local showDatePicker = function(event)
         mui.newDatePicker({
+            parent = muiData.parent,
             name = "datepicker-demo",
             font = native.systemFont,
             fontSize = mui.getScaleVal(26),
@@ -228,6 +235,7 @@ function scene:create( event )
         })
     end
     mui.newCircleButton({
+        parent = muiData.parent,
         name = "alice-button",
         text = "date_range",
         radius = mui.getScaleVal(46),
@@ -242,6 +250,7 @@ function scene:create( event )
     -- time picker example
     local showTimePicker = function(event)
         mui.newTimePicker({
+            parent = muiData.parent,
             name = "timepicker-demo",
             font = native.systemFont,
             width = mui.getScaleVal(400),
@@ -266,6 +275,7 @@ function scene:create( event )
         })
     end
     mui.newCircleButton({
+        parent = muiData.parent,
         name = "bueler-button",
         text = "access_time",
         radius = mui.getScaleVal(46),
@@ -281,6 +291,7 @@ function scene:create( event )
     -- slide panel example
     local showSlidePanel = function(event)
         mui.newSlidePanel({
+            parent = muiData.parent,
             name = "slidepanel-demo",
             title = "MUI Demo", -- leave blank for no panel title text
             titleAlign = "center",
@@ -328,6 +339,7 @@ function scene:create( event )
 
     end
     mui.newCircleButton({
+        parent = muiData.parent,
         name = "slidepanel-button",
         text = "menu",
         radius = mui.getScaleVal(46),
@@ -345,6 +357,7 @@ function scene:create( event )
         local button = mui.getWidgetBaseObject( "vertical-menu-button" )
 
         mui.newPopover({
+            parent = muiData.parent,
             name = "popovermenu_demo1",
             font = native.systemFont,
             textColor = { 0.4, 0.4, 0.4 },
@@ -371,6 +384,7 @@ function scene:create( event )
     end
 
     mui.newIconButton({
+        parent = muiData.parent,
         name = "vertical-menu-button",
         text = "more_vert",
         width = mui.getScaleVal(46),
@@ -384,8 +398,48 @@ function scene:create( event )
         callBack = showPopover
     })
 
+    -- SnackBar example
+    local function showSnackBar( ... )
+        mui.newSnackBar({
+            parent = muiData.parent,
+            name = "snackbar_demo1",
+            text = "Updated Demo",
+            radius = mui.getScaleVal(10),
+            width = mui.getScaleVal(220),
+            height = mui.getScaleVal(50),
+            font = native.systemFont,
+            fontSize = mui.getScaleVal(20),
+            fillColor = { 0, 0, 0, 1 },
+            textColor = { 1, 1, 1, 1 },
+            bottom = mui.getScaleVal(80),
+            easingIn = 500,
+            easingOut = 500,
+            timeOut = 3000,
+            buttonFont = native.systemFontBold,
+            buttonText = "UNDO",
+            buttonTextColor = { 1, 0.23, 0.5, 1 },
+            callBack = mui.actionForButton
+        })
+    end
+
+    mui.newIconButton({
+        parent = muiData.parent,
+        name = "snackbar_button",
+        text = "local_cafe",
+        width = mui.getScaleVal(46),
+        height = mui.getScaleVal(46),
+        x = mui.getScaleVal(570),
+        y = mui.getScaleVal(420),
+        font = "MaterialIcons-Regular.ttf",
+        textColor = { 0, 0, 0, 1 },
+        fillColor = { 0, 0.46, 1 },
+        textAlign = "center",
+        callBack = showSnackBar
+    })
+
     -- tile widget example
     mui.newCircleButton({
+        parent = muiData.parent,
         name = "tile-button",
         text = "view_list",
         radius = mui.getScaleVal(46),
@@ -403,6 +457,7 @@ function scene:create( event )
 
     -- checkbox example
     mui.newCheckBox({
+        parent = muiData.parent,
         name = "check",
         text = "check_box_outline_blank",
         width = mui.getScaleVal(50),
@@ -418,6 +473,7 @@ function scene:create( event )
 
     -- toggle switch example
     mui.newToggleSwitch({
+        parent = muiData.parent,
         name = "switch_demo",
         size = mui.getScaleVal(55),
         x = mui.getScaleVal(360),
@@ -433,6 +489,7 @@ function scene:create( event )
 
     -- radio button group example
     mui.newRadioGroup({
+        parent = muiData.parent,
         name = "radio_demo",
         width = mui.getScaleVal(30),
         height = mui.getScaleVal(30),
@@ -450,8 +507,9 @@ function scene:create( event )
         }
     })
 
-    ---[[--
+    ---[[
     mui.newTableView({
+        parent = muiData.parent,
         name = "tableview_demo",
         width = mui.getScaleVal(300),
         height = mui.getScaleVal(300),
@@ -485,6 +543,7 @@ function scene:create( event )
     --]]--
 
     mui.newTextField({
+        parent = muiData.parent,
         name = "textfield_demo",
         labelText = "Subject",
         text = "Hello, world!",
@@ -500,6 +559,7 @@ function scene:create( event )
 
     -- create and animate the intial value (1% is always required due to scaling method)
     mui.newProgressBar({
+        parent = muiData.parent,
         name = "progressbar_demo",
         width = mui.getScaleVal(290),
         height = mui.getScaleVal(8),
@@ -531,6 +591,7 @@ function scene:create( event )
     -- on bottom and stay on top of other widgets.
     local buttonHeight = mui.getScaleVal(70)
     mui.newToolbar({
+        parent = muiData.parent,
         name = "toolbar_demo",
         --width = mui.getScaleVal(500), -- defaults to display.contentWidth
         height = mui.getScaleVal(70),


### PR DESCRIPTION
## [0.1.50] - 2017-01-08
### Added
- Method "newSnackBar" for creating snack bar and action button text. These flow up from the bottom.  Like "Removed Msgs  UNDO" and it times out after 3 seconds.  Use "timeOut" to specify timeout in microseconds.

### Change
- Fixed all "parent" group/scene parameter for all controls.  The demo is updated using a parent for all buttons.  Click "coffee cup" to see all the controls slide up (snack bar).
