### PR TITLE
added parameter 'iconImage' to list {} which is the PNG/JPG of icon f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.53] - 2017-01-09
+### Added
+- 'iconImage' parameter to newToolbar() method.  It will fit the image to the font size dimensions. This is so it will look correct. See demo and "list {}" for an example.
+
 ## [0.1.52] - 2017-01-09
 ### Added
 - 'iconImage' parameter to newSlidePanel() method.  It will fit the image to the font size dimensions. This is so it will look correct. See demo and "list {}" for an example.

--- a/materialui/mui-toolbar.lua
+++ b/materialui/mui-toolbar.lua
@@ -191,14 +191,25 @@ function M.newToolbarButton( options )
         align = "center"
     }
 
-    button["myText"] = display.newText( options2 )
-    button["myText"]:setFillColor( unpack(textColor) )
+    if options.iconImage ~= nil then
+        button["myText"] = display.newImageRect( options.iconImage, textSize, textSize )
+        button["myText"].y = textY
+        button["myText"].isImage = true
+    else
+        button["myText"] = display.newText( options2 )
+        button["myText"]:setFillColor( unpack(textColor) )
+        button["myText"].isImage = false
+    end
     button["myText"].isVisible = true
     if isChecked then
-        button["myText"]:setFillColor( unpack(options.labelColor) )
+        if button["myText"].isImage == false then
+            button["myText"]:setFillColor( unpack(options.labelColor) )
+        end
         button["myText"].isChecked = isChecked
     else
-        button["myText"]:setFillColor( unpack(options.labelColorOff) )
+        if button["myText"].isImage == false then
+            button["myText"]:setFillColor( unpack(options.labelColorOff) )
+        end
         button["myText"].isChecked = false
     end
     button["mygroup"]:insert( button["myText"], false )
@@ -398,6 +409,7 @@ function M.newToolbar( options )
                 textAlign = "center",
                 labelColor = options.labelColor,
                 backgroundColor = options.color or options.fillColor,
+                iconImage = v.iconImage,
                 numberOfButtons = count,
                 callBack = options.callBack,
                 callBackData = options.callBackData
@@ -454,7 +466,9 @@ function M.actionForToolbar( options, e )
         end
         for k, v in pairs(list) do
             if v["myText"] ~= nil then
-                v["myText"]:setFillColor( unpack(muiData.widgetDict[basename]["toolbar"]["labelColorOff"]) )
+                if v["myText"].isImage == false then
+                    v["myText"]:setFillColor( unpack(muiData.widgetDict[basename]["toolbar"]["labelColorOff"]) )
+                end
                 if v["myText2"] ~= nil then
                     v["myText2"]:setFillColor( unpack(muiData.widgetDict[basename]["toolbar"]["labelColorOff"]) )
                 end
@@ -462,7 +476,9 @@ function M.actionForToolbar( options, e )
             end
         end
 
-        target:setFillColor( unpack(muiData.widgetDict[basename]["toolbar"]["labelColor"]) )
+        if target.isImage == false then
+            target:setFillColor( unpack(muiData.widgetDict[basename]["toolbar"]["labelColor"]) )
+        end
         if target2 ~= nil then
             target2:setFillColor( unpack(muiData.widgetDict[basename]["toolbar"]["labelColor"]) )
         end
@@ -479,7 +495,7 @@ function M.actionForToolbarDemo( event )
     local muiTarget = M.getEventParameter(event, "muiTarget")
     local muiTargetValue = M.getEventParameter(event, "muiTargetValue")
 
-    if muiTarget ~= nil then
+    if muiTarget ~= nil and muiTarget.text ~= nil then
         print("Toolbar button text: " .. muiTarget.text)
     end
     if muiTargetValue ~= nil then

--- a/menu.lua
+++ b/menu.lua
@@ -608,6 +608,7 @@ function scene:create( event )
         callBack = mui.actionForToolbarDemo,
         sliderColor = { 1, 1, 1 },
         list = {
+            -- note use iconImage="<filename of jpg/png>" for custom graphic icons
             { key = "Home", value = "1", icon="home", labelText="Home", isActive = true },
             { key = "Newsroom", value = "2", icon="new_releases", labelText="News", isActive = false },
             { key = "Location", value = "3", icon="location_searching", labelText="Location", isActive = false },


### PR DESCRIPTION
## [0.1.53] - 2017-01-09
### Added
- 'iconImage' parameter to newToolbar() method.  It will fit the image to the font size dimensions. This is so it will look correct. See demo and "list {}" for an example.
