### PR TITLE
fixed bug where newSlidePanel forced white background on buttons, use…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.54] - 2017-01-11
+### Change
+- Fixed bug where newSlidePanel forced white background on buttons, user-defined now.  It uses the background color of the whole panel by parameter "fillColor"
+
 ## [0.1.53] - 2017-01-09
 ### Added
 - 'iconImage' parameter to newToolbar() method.  It will fit the image to the font size dimensions. This is so it will look correct. See demo and "list {}" for an example.

--- a/materialui/mui-slidepanel.lua
+++ b/materialui/mui-slidepanel.lua
@@ -374,7 +374,8 @@ function M.newSlidePanelButton( options )
     local buttonWidth = textWidth
     local buttonHeight = textHeight
     local rectangle = display.newRect( buttonWidth * 0.5, 0, buttonWidth, buttonHeight )
-    rectangle:setFillColor( unpack({1,1,1,0}) ) -- options.backgroundColor
+    options.backgroundColor = options.backgroundColor or { 1, 1, 1, 1 }
+    rectangle:setFillColor( unpack( options.backgroundColor ) ) -- options.backgroundColor
     button["rectangle"] = rectangle
     button["rectangle"].value = options.value
     button["buttonWidth"] = rectangle.contentWidth


### PR DESCRIPTION
## [0.1.54] - 2017-01-11
### Change
- Fixed bug where newSlidePanel forced white background on buttons, user-defined now.  It uses the background color of the whole panel by parameter "fillColor"
