### PR TITLE
added 'iconColor', 'iconColoroff' for color support for newToolbar an…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.55] - 2017-01-11
+### Added
+- 'iconColor' parameter to newToolbar list {} options. Specify color in on state per icon.
+- 'iconColorOff' parameter to newToolbar list {} options. Specify color in off state per icon.
+- 'iconColor' parameter to newSlidePanel list {} options. Specify color in on state per icon.
+- 'iconColorOff' parameter to newSlidePanel list {} options. Specify color in off state per icon.
+
+### Fixed
+- Color bugs in newSlidePanel and newToolbar methods.
+
 ## [0.1.54] - 2017-01-11
 ### Change
 - Fixed bug where newSlidePanel forced white background on buttons, user-defined now.  It uses the background color of the whole panel by parameter "fillColor"

--- a/materialui/mui-slidepanel.lua
+++ b/materialui/mui-slidepanel.lua
@@ -189,6 +189,8 @@ function M.newSlidePanel(options)
                 textAlign = "center",
                 labelColor = options.labelColor,
                 labelColorOff = options.labelColorOff,
+                iconColor = v.iconColor or options.labelColor,
+                iconColorOff = v.iconColorOff or options.labelColorOff,
                 backgroundColor = options.fillColor,
                 buttonHighlightColor = options.buttonHighlightColor,
                 buttonHighlightColorAlpha = (options.buttonHighlightColorAlpha or 0.5),
@@ -317,8 +319,10 @@ function M.newSlidePanelButton( options )
     if options.labelColor == nil then
         options.labelColor = { 1, 1, 1 }
     end
-    muiData.widgetDict[options.basename]["slidebar"]["labelColorOff"] = options.labelColorOff
-    muiData.widgetDict[options.basename]["slidebar"]["labelColor"] = options.labelColor
+    muiData.widgetDict[options.basename]["slidebar"][options.name]["labelColorOff"] = options.labelColorOff
+    muiData.widgetDict[options.basename]["slidebar"][options.name]["labelColor"] = options.labelColor
+    muiData.widgetDict[options.basename]["slidebar"][options.name]["iconColorOff"] = options.iconColorOff
+    muiData.widgetDict[options.basename]["slidebar"][options.name]["iconColor"] = options.iconColor
 
     local fontSize = options.buttonHeight
     if options.fontSize ~= nil then
@@ -375,7 +379,7 @@ function M.newSlidePanelButton( options )
     local buttonHeight = textHeight
     local rectangle = display.newRect( buttonWidth * 0.5, 0, buttonWidth, buttonHeight )
     options.backgroundColor = options.backgroundColor or { 1, 1, 1, 1 }
-    rectangle:setFillColor( unpack( options.backgroundColor ) ) -- options.backgroundColor
+    rectangle:setFillColor( unpack( options.backgroundColor ) )
     button["rectangle"] = rectangle
     button["rectangle"].value = options.value
     button["buttonWidth"] = rectangle.contentWidth
@@ -411,13 +415,12 @@ function M.newSlidePanelButton( options )
         button["myText"] = display.newImageRect( options.iconImage, textSize, textSize )
     else
         button["myText"] = display.newText( options2 )
-        button["myText"]:setFillColor( unpack(options.labelColorOff) )
         button["myText"].isVisible = true
         if isChecked then
-            button["myText"]:setFillColor( unpack(options.labelColor) )
+            button["myText"]:setFillColor( unpack(options.iconColor) )
             button["myText"].isChecked = isChecked
         else
-            button["myText"]:setFillColor( unpack(options.labelColorOff) )
+            button["myText"]:setFillColor( unpack(options.iconColorOff) )
             button["myText"].isChecked = false
         end
     end

--- a/materialui/mui-toolbar.lua
+++ b/materialui/mui-toolbar.lua
@@ -85,12 +85,15 @@ function M.newToolbarButton( options )
     -- label colors
     if options.labelColorOff == nil then
         options.labelColorOff = { 0, 0, 0 }
+        print("WHIIOP?")
     end
     if options.labelColor == nil then
         options.labelColor = { 1, 1, 1 }
     end
-    muiData.widgetDict[options.basename]["toolbar"]["labelColorOff"] = options.labelColorOff
-    muiData.widgetDict[options.basename]["toolbar"]["labelColor"] = options.labelColor
+    muiData.widgetDict[options.basename]["toolbar"][options.name]["labelColorOff"] = options.labelColorOff
+    muiData.widgetDict[options.basename]["toolbar"][options.name]["labelColor"] = options.labelColor
+    muiData.widgetDict[options.basename]["toolbar"][options.name]["iconColorOff"] = options.iconColorOff or options.labelColorOff
+    muiData.widgetDict[options.basename]["toolbar"][options.name]["iconColor"] = options.iconColor or options.labelColor
 
     local radius = options.height * 0.2
     if options.radius ~= nil and options.radius < options.height and options.radius > 1 then
@@ -108,9 +111,9 @@ function M.newToolbarButton( options )
         font = options.font
     end
 
-    local textColor = { 0, 0.82, 1 }
-    if options.textColor ~= nil then
-        textColor = options.textColor
+    local iconColor = { 0, 0.82, 1 }
+    if options.iconColor ~= nil then
+        iconColor = options.iconColor
     end
 
     local useBothIconAndText = false
@@ -197,18 +200,18 @@ function M.newToolbarButton( options )
         button["myText"].isImage = true
     else
         button["myText"] = display.newText( options2 )
-        button["myText"]:setFillColor( unpack(textColor) )
+        --button["myText"]:setFillColor( unpack(options.iconColor) )
         button["myText"].isImage = false
     end
     button["myText"].isVisible = true
     if isChecked then
         if button["myText"].isImage == false then
-            button["myText"]:setFillColor( unpack(options.labelColor) )
+            button["myText"]:setFillColor( unpack(options.iconColor) )
         end
         button["myText"].isChecked = isChecked
     else
         if button["myText"].isImage == false then
-            button["myText"]:setFillColor( unpack(options.labelColorOff) )
+            button["myText"]:setFillColor( unpack(options.iconColorOff) )
         end
         button["myText"].isChecked = false
     end
@@ -228,7 +231,7 @@ function M.newToolbarButton( options )
             align = "center"
         }
         button["myText2"] = display.newText( options3 )
-        button["myText2"]:setFillColor( unpack(textColor) )
+        button["myText2"]:setFillColor( unpack(options.labelColor) )
         button["myText2"].isVisible = true
         if isChecked then
             button["myText2"]:setFillColor( unpack(options.labelColor) )
@@ -242,7 +245,7 @@ function M.newToolbarButton( options )
 
     -- add the animated circle
 
-    local circleColor = textColor
+    local circleColor = iconColor
     if options.circleColor ~= nil then
         circleColor = options.circleColor
     end
@@ -341,6 +344,9 @@ function M.toolBarButton (event)
                 event.callBackData = options.callBackData
 
                 muiData.widgetDict[options.basename]["value"] = options.value
+                M.setEventParameter(event, "muiLabelColor", muiData.widgetDict[options.basename]["toolbar"][options.name]["labelColor"])
+                M.setEventParameter(event, "muiIconColor", muiData.widgetDict[options.basename]["toolbar"][options.name]["iconColor"])
+                M.setEventParameter(event, "muiTargetValue", options.value)
                 M.setEventParameter(event, "muiTargetValue", options.value)
                 M.setEventParameter(event, "muiTarget", muiData.widgetDict[options.basename]["toolbar"][options.name]["myText"])
                 M.setEventParameter(event, "muiTarget2", muiData.widgetDict[options.basename]["toolbar"][options.name]["myText2"])
@@ -380,7 +386,6 @@ function M.newToolbar( options )
         muiData.widgetDict[options.name]["layout"] = options.layout
         if muiData.widgetDict[options.name]["layout"] == "horizontal" then
             muiData.widgetDict[options.name]["y_position"] = y
-            print("height is "..muiData.contentHeight)
         end
         for i, v in ipairs(options.list) do
             M.newToolbarButton({
@@ -404,10 +409,11 @@ function M.newToolbar( options )
                 labelText = v.labelText,
                 labelFont = options.labelFont,
                 labelFontSize = options.labelFontSize,
-                textColor = options.labelColor,
-                textColorOff = options.labelColorOff,
                 textAlign = "center",
                 labelColor = options.labelColor,
+                labelColorOff = options.labelColorOff,
+                iconColor = v.iconColor or options.labelColor,
+                iconColorOff = v.iconColorOff or options.labelColorOff,
                 backgroundColor = options.color or options.fillColor,
                 iconImage = v.iconImage,
                 numberOfButtons = count,
@@ -464,23 +470,27 @@ function M.actionForToolbar( options, e )
         if target.isChecked == true then
             return
         end
+
         for k, v in pairs(list) do
             if v["myText"] ~= nil then
                 if v["myText"].isImage == false then
-                    v["myText"]:setFillColor( unpack(muiData.widgetDict[basename]["toolbar"]["labelColorOff"]) )
+                    v["myText"]:setFillColor( unpack(v["iconColorOff"]) )
                 end
                 if v["myText2"] ~= nil then
-                    v["myText2"]:setFillColor( unpack(muiData.widgetDict[basename]["toolbar"]["labelColorOff"]) )
+                    v["myText2"]:setFillColor( unpack(v["labelColorOff"]) )
                 end
                 v["myText"].isChecked = false
             end
         end
 
+       local muiLabelColor = M.getEventParameter(e, "muiLabelColor")
+       local muiIconColor = M.getEventParameter(e, "muiIconColor")
+
         if target.isImage == false then
-            target:setFillColor( unpack(muiData.widgetDict[basename]["toolbar"]["labelColor"]) )
+            target:setFillColor( unpack( muiIconColor ) )
         end
         if target2 ~= nil then
-            target2:setFillColor( unpack(muiData.widgetDict[basename]["toolbar"]["labelColor"]) )
+            target2:setFillColor( unpack( muiLabelColor ) )
         end
         target.isChecked = true
         assert( options.callBack )(e)

--- a/menu.lua
+++ b/menu.lua
@@ -318,8 +318,8 @@ function scene:create( event )
             list = {
                 { key = "Home", value = "1", icon="home", iconImage="1484022678_go-home.png", labelText="Home", isActive = true },
                 { key = "Newsroom", value = "2", icon="new_releases", iconImage="1484026171_02.png", labelText="News", isActive = false },
-                { key = "Location", value = "3", icon="location_searching", labelText="Location Information", isActive = false },
-                { key = "To-do", value = "4", icon="view_list", labelText="To-do", isActive = false },
+                { key = "Location", value = "3", icon="location_searching", labelText="Location Information", isActive = false, iconColor = { 0.26, 0.52, 0.96, 1 }, iconColorOff = { 0.26, 0.52, 0.96, 1 } },
+                { key = "To-do", value = "4", icon="view_list", labelText="To-do", isActive = false, iconColor = { 0.92, 0.26, 0.21, 1 }, iconColorOff = { 0.92, 0.26, 0.21, 1 } },
                 { key = "LineSeparator" },
                 { key = "To-do 2", value = "To-do 2", icon="view_list", labelText="To-do 2", isActive = false },
                 { key = "To-do 3", value = "To-do 3", icon="view_list", labelText="To-do 3", isActive = false },
@@ -604,13 +604,13 @@ function scene:create( event )
         color = { 0, 0.46, 1 },
         fillColor = { 0, 0.46, 1 },
         labelColor = { 1, 1, 1 },
-        labelColorOff = { 0.41, 0.03, 0.49 },
+        labelColorOff = { 0, 0, 0 },
         callBack = mui.actionForToolbarDemo,
         sliderColor = { 1, 1, 1 },
         list = {
             -- note use iconImage="<filename of jpg/png>" for custom graphic icons
-            { key = "Home", value = "1", icon="home", labelText="Home", isActive = true },
-            { key = "Newsroom", value = "2", icon="new_releases", labelText="News", isActive = false },
+            { key = "Home", value = "1", icon="home", labelText="Home", isActive = true, iconColor = { 1, 1, 1 }, iconColorOff = { 0,0,0,1 } },
+            { key = "Newsroom", value = "2", icon="new_releases", labelText="News", isActive = false, iconColor = { 1, 1, 1 }, iconColorOff = { 0,0,0,1 } },
             { key = "Location", value = "3", icon="location_searching", labelText="Location", isActive = false },
             { key = "To-do", value = "4", icon="view_list", labelText="To-do", isActive = false },
             -- { key = "Viewer", value = "4", labelText="View", isActive = false } -- uncomment to see View as text


### PR DESCRIPTION
## [0.1.55] - 2017-01-11
### Added
- 'iconColor' parameter to newToolbar list {} options. Specify color in on state per icon.
- 'iconColorOff' parameter to newToolbar list {} options. Specify color in off state per icon.
- 'iconColor' parameter to newSlidePanel list {} options. Specify color in on state per icon.
- 'iconColorOff' parameter to newSlidePanel list {} options. Specify color in off state per icon.

### Fixed
- Color bugs in newSlidePanel and newToolbar methods.
