### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 - 'closeSlidePanel()' method to close a newSlidePanel() widget by name.  This is now the default action if used the built-in callBack.  You may call this in your own callBacks.
 Example: mui.closeSlidePanel("slidepanel-demo")
 - 'callBack' parameter added to each menu item.  If used this callBack will be called instead of the parent callBack for the entire newSlidePanel() widget.
-- 'callBackData' parameter added to each menu item. if used the data will be passed to the callBack being usde.
+- 'callBackData' parameter added to each menu item. if used the data will be passed to the callBack being used.
 
 ## [0.1.58] - 2017-01-19
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.59] - 2017-01-19
+### Added
+- 'closeSlidePanel()' method to close a newSlidePanel() widget by name.  This is now the default action if used the built-in callBack.  You may call this in your own callBacks.
+Example: mui.closeSlidePanel("slidepanel-demo")
+- 'callBack' parameter added to each menu item.  If used this callBack will be called instead of the parent callBack for the entire newSlidePanel() widget.
+- 'callBackData' parameter added to each menu item. if used the data will be passed to the callBack being usde.
+
 ## [0.1.58] - 2017-01-19
 ### Changes
 - Fixed issue #143 reported by StevenWarren: "useActualDimensions" parameter to mui.init() was setting useActualDimensions to true.

--- a/materialui/mui-slidepanel.lua
+++ b/materialui/mui-slidepanel.lua
@@ -195,8 +195,8 @@ function M.newSlidePanel(options)
                 buttonHighlightColor = options.buttonHighlightColor,
                 buttonHighlightColorAlpha = (options.buttonHighlightColorAlpha or 0.5),
                 numberOfButtons = count,
-                callBack = options.callBack,
-                callBackData = options.callBackData
+                callBack = v.callBack or options.callBack,
+                callBackData = v.callBackData or options.callBackData
             })
             else
                 M.newSlidePanelLineSeparator({
@@ -557,8 +557,10 @@ function M.slidePanelEventButton (event)
 end
 
 function M.sliderButtonResetColor( e )
-    e:setFillColor( unpack(e.muiOptions.backgroundColor) )
-    e.alpha = 0.01
+    if e.target ~= nil then
+        e:setFillColor( unpack(e.muiOptions.backgroundColor) )
+        e.alpha = 0.01
+    end
 end
 
 function M.actionForSlidePanel( options, e )
@@ -571,6 +573,19 @@ function M.actionForSlidePanel( options, e )
     end
     if muiTargetCallBackData ~= nil then
         print("Item from callBackData: "..muiTargetCallBackData.item)
+    end
+    if e.myTargetBasename ~= nil then
+        M.closeSlidePanel(e.myTargetBasename)
+    end
+end
+
+function M.closeSlidePanel( widgetName )
+    if widgetName ~= nil and muiData.widgetDict[widgetName] ~= nil then
+        event = {}
+        event.target = muiData.widgetDict[widgetName]["scrollview"]
+        event.target.muiOptions = muiData.widgetDict[widgetName]["mygroup"].muiOptions
+        event.phase = "ended"
+        M.touchSlidePanelBarrier( event )
     end
 end
 

--- a/menu.lua
+++ b/menu.lua
@@ -289,6 +289,11 @@ function scene:create( event )
     })
 
     -- slide panel example
+    local closeSlidePanel = function(event)
+        print("home bound")
+        mui.closeSlidePanel("slidepanel-demo")
+    end
+
     local showSlidePanel = function(event)
         mui.newSlidePanel({
             parent = muiData.parent,
@@ -316,7 +321,7 @@ function scene:create( event )
             buttonHighlightColorAlpha = 0.5,
             lineSeparatorHeight = mui.getScaleVal(1),
             list = {
-                { key = "Home", value = "1", icon="home", iconImage="1484022678_go-home.png", labelText="Home", isActive = true },
+                { key = "Home", value = "1", icon="home", iconImage="1484022678_go-home.png", labelText="Home", isActive = true, callBack = closeSlidePanel },
                 { key = "Newsroom", value = "2", icon="new_releases", iconImage="1484026171_02.png", labelText="News", isActive = false },
                 { key = "Location", value = "3", icon="location_searching", labelText="Location Information", isActive = false, iconColor = { 0.26, 0.52, 0.96, 1 }, iconColorOff = { 0.26, 0.52, 0.96, 1 } },
                 { key = "To-do", value = "4", icon="view_list", labelText="To-do", isActive = false, iconColor = { 0.92, 0.26, 0.21, 1 }, iconColorOff = { 0.92, 0.26, 0.21, 1 } },


### PR DESCRIPTION
## [0.1.59] - 2017-01-19
### Added
- 'closeSlidePanel()' method to close a newSlidePanel() widget by name.  This is now the default action if used the built-in callBack.  You may call this in your own callBacks.
Example: mui.closeSlidePanel("slidepanel-demo")
- 'callBack' parameter added to each menu item.  If used this callBack will be called instead of the parent callBack for the entire newSlidePanel() widget.
- 'callBackData' parameter added to each menu item. if used the data will be passed to the callBack being used.
