### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.] - 2017-01-19
+### Added
+- 'hideSlidePanel()' method to hide a newSlidePanel() widget by name. This can be used in your callBacks. You may call this in your own callBacks.  This keeps the newSlidePanel in memory and hides it.  See menu.lua for example.
+- 'showSlidePanel()' method to show a newSlidePanel() widget by name. This can be used in your callBacks. You may call this in your own callBacks. This uses the newSlidePanel in memory and shows it.
+See menu.lua for example.
+
 ## [0.1.59] - 2017-01-19
 ### Added
 - 'closeSlidePanel()' method to close a newSlidePanel() widget by name.  This is now the default action if used the built-in callBack.  You may call this in your own callBacks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.1.] - 2017-01-19
+## [0.1.60] - 2017-01-19
 ### Added
 - 'hideSlidePanel()' method to hide a newSlidePanel() widget by name. This can be used in your callBacks. You may call this in your own callBacks.  This keeps the newSlidePanel in memory and hides it.  See menu.lua for example.
 - 'showSlidePanel()' method to show a newSlidePanel() widget by name. This can be used in your callBacks. You may call this in your own callBacks. This uses the newSlidePanel in memory and shows it.

--- a/materialui/mui-slidepanel.lua
+++ b/materialui/mui-slidepanel.lua
@@ -579,6 +579,40 @@ function M.actionForSlidePanel( options, e )
     end
 end
 
+function M.showSlidePanel( widgetName )
+    if widgetName ~= nil and muiData.widgetDict[widgetName] ~= nil then
+        -- animate the menu button
+        if muiData.widgetDict[widgetName]["buttonToAnimate"] ~= nil then
+            transition.to( muiData.widgetDict[widgetName]["buttonToAnimate"], { rotation=90, time=300, transition=easing.inOutCubic } )
+        end
+        local options = muiData.widgetDict[widgetName]["mygroup"].muiOptions
+        transition.fadeIn(muiData.widgetDict[widgetName]["rectclick"],{time=300})
+        transition.fadeIn(muiData.widgetDict[widgetName]["rectbackdrop"],{time=300})
+        transition.to( muiData.widgetDict[widgetName]["scrollview"], { time=300, x=(options.width * 0.5), transition=easing.linear } )
+        muiData.dialogName = widgetName
+        muiData.dialogInUse = true
+        muiData.slidePanelName = widgetName
+        muiData.slidePanelInUse = true
+    end
+end
+
+function M.hideSlidePanel( widgetName )
+    if widgetName ~= nil and muiData.widgetDict[widgetName] ~= nil then
+        local options = muiData.widgetDict[widgetName]["mygroup"].muiOptions
+        transition.to( muiData.widgetDict[widgetName]["scrollview"], { time=300, x=-(options.width * 0.5), transition=easing.linear } )
+        transition.fadeOut(muiData.widgetDict[widgetName]["rectbackdrop"],{time=300})
+        transition.fadeOut(muiData.widgetDict[widgetName]["rectclick"],{time=300})
+        muiData.dialogName = nil
+        muiData.dialogInUse = false
+        muiData.slidePanelName = nil
+        muiData.slidePanelInUse = false
+        -- animate the menu button
+        if muiData.widgetDict[options.name]["buttonToAnimate"] ~= nil then
+            transition.to( muiData.widgetDict[options.name]["buttonToAnimate"], { rotation=0, time=300, transition=easing.inOutCubic } )
+        end
+    end
+end
+
 function M.closeSlidePanel( widgetName )
     if widgetName ~= nil and muiData.widgetDict[widgetName] ~= nil then
         event = {}

--- a/menu.lua
+++ b/menu.lua
@@ -289,60 +289,67 @@ function scene:create( event )
     })
 
     -- slide panel example
-    local closeSlidePanel = function(event)
-        print("home bound")
-        mui.closeSlidePanel("slidepanel-demo")
+    local hideSlidePanel = function(event)
+        print("home button pushed")
+        -- or use close method below to close and release slider from memory
+        -- mui.closeSlidePanel("slidepanel-demo")
+        mui.hideSlidePanel("slidepanel-demo")
     end
 
     local showSlidePanel = function(event)
-        mui.newSlidePanel({
-            parent = muiData.parent,
-            name = "slidepanel-demo",
-            title = "MUI Demo", -- leave blank for no panel title text
-            titleAlign = "center",
-            font = native.systemFont,
-            width = mui.getScaleVal(400),
-            titleFontSize = mui.getScaleVal(30),
-            titleFontColor = { 1, 1, 1, 1 },
-            titleFont = native.systemFont,
-            titleBackgroundColor = { 0.25, 0.75, 1, 1 },
-            fontSize = mui.getScaleVal(20),
-            fillColor = { 1, 1, 1, 1 }, -- background color
-            headerImage = "creative-blue-abstract-background-header-4803_0.jpg",
-            buttonToAnimate = "slidepanel-button",
-            callBack = mui.actionForSlidePanel,
-            callBackData = {
-                item = "cake"
-            },
-            labelColor = { 0.3, 0.3, 0.3, 1 }, -- active
-            labelColorOff = { 0.5, 0.5, 0.5, 1 }, -- non-active
-            buttonHeight = mui.getScaleVal(60),
-            buttonHighlightColor = { 0.5, 0.5, 0.5 },
-            buttonHighlightColorAlpha = 0.5,
-            lineSeparatorHeight = mui.getScaleVal(1),
-            list = {
-                { key = "Home", value = "1", icon="home", iconImage="1484022678_go-home.png", labelText="Home", isActive = true, callBack = closeSlidePanel },
-                { key = "Newsroom", value = "2", icon="new_releases", iconImage="1484026171_02.png", labelText="News", isActive = false },
-                { key = "Location", value = "3", icon="location_searching", labelText="Location Information", isActive = false, iconColor = { 0.26, 0.52, 0.96, 1 }, iconColorOff = { 0.26, 0.52, 0.96, 1 } },
-                { key = "To-do", value = "4", icon="view_list", labelText="To-do", isActive = false, iconColor = { 0.92, 0.26, 0.21, 1 }, iconColorOff = { 0.92, 0.26, 0.21, 1 } },
-                { key = "LineSeparator" },
-                { key = "To-do 2", value = "To-do 2", icon="view_list", labelText="To-do 2", isActive = false },
-                { key = "To-do 3", value = "To-do 3", icon="view_list", labelText="To-do 3", isActive = false },
-                { key = "To-do 4", value = "To-do 4", icon="view_list", labelText="To-do 4", isActive = false },
-                { key = "To-do 5", value = "To-do 5", icon="view_list", labelText="To-do 5", isActive = false },
-                { key = "LineSeparator" },
-                { key = "To-do 6", value = "To-do 6", icon="view_list", labelText="To-do 6", isActive = false },
-                { key = "To-do 7", value = "To-do 7", icon="view_list", labelText="To-do 7", isActive = false },
-                { key = "To-do 8", value = "To-do 8", icon="view_list", labelText="To-do 8", isActive = false },
-                { key = "To-do 9", value = "To-do 9", icon="view_list", labelText="To-do 9", isActive = false },
-                { key = "To-do 10", value = "To-do 10", icon="view_list", labelText="To-do 10", isActive = false },
-                { key = "LineSeparator" },
-                { key = "To-do 11", value = "To-do 11", icon="view_list", labelText="To-do 11", isActive = false },
-                { key = "To-do 12", value = "To-do 12", icon="view_list", labelText="To-do 12", isActive = false },
-            },
-        })
+        if mui.getWidgetBaseObject("slidepanel-demo") ~= nil then
+            mui.showSlidePanel("slidepanel-demo")
+            print("slidePanel exists, show it")
+        else
+            print("slidePanel is new")
+            mui.newSlidePanel({
+                parent = muiData.parent,
+                name = "slidepanel-demo",
+                title = "MUI Demo", -- leave blank for no panel title text
+                titleAlign = "center",
+                font = native.systemFont,
+                width = mui.getScaleVal(400),
+                titleFontSize = mui.getScaleVal(30),
+                titleFontColor = { 1, 1, 1, 1 },
+                titleFont = native.systemFont,
+                titleBackgroundColor = { 0.25, 0.75, 1, 1 },
+                fontSize = mui.getScaleVal(20),
+                fillColor = { 1, 1, 1, 1 }, -- background color
+                headerImage = "creative-blue-abstract-background-header-4803_0.jpg",
+                buttonToAnimate = "slidepanel-button",
+                callBack = mui.actionForSlidePanel,
+                callBackData = {
+                    item = "cake"
+                },
+                labelColor = { 0.3, 0.3, 0.3, 1 }, -- active
+                labelColorOff = { 0.5, 0.5, 0.5, 1 }, -- non-active
+                buttonHeight = mui.getScaleVal(60),
+                buttonHighlightColor = { 0.5, 0.5, 0.5 },
+                buttonHighlightColorAlpha = 0.5,
+                lineSeparatorHeight = mui.getScaleVal(1),
+                list = {
+                    { key = "Home", value = "1", icon="home", iconImage="1484022678_go-home.png", labelText="Home", isActive = true, callBack = hideSlidePanel },
+                    { key = "Newsroom", value = "2", icon="new_releases", iconImage="1484026171_02.png", labelText="News", isActive = false },
+                    { key = "Location", value = "3", icon="location_searching", labelText="Location Information", isActive = false, iconColor = { 0.26, 0.52, 0.96, 1 }, iconColorOff = { 0.26, 0.52, 0.96, 1 } },
+                    { key = "To-do", value = "4", icon="view_list", labelText="To-do", isActive = false, iconColor = { 0.92, 0.26, 0.21, 1 }, iconColorOff = { 0.92, 0.26, 0.21, 1 } },
+                    { key = "LineSeparator" },
+                    { key = "To-do 2", value = "To-do 2", icon="view_list", labelText="To-do 2", isActive = false },
+                    { key = "To-do 3", value = "To-do 3", icon="view_list", labelText="To-do 3", isActive = false },
+                    { key = "To-do 4", value = "To-do 4", icon="view_list", labelText="To-do 4", isActive = false },
+                    { key = "To-do 5", value = "To-do 5", icon="view_list", labelText="To-do 5", isActive = false },
+                    { key = "LineSeparator" },
+                    { key = "To-do 6", value = "To-do 6", icon="view_list", labelText="To-do 6", isActive = false },
+                    { key = "To-do 7", value = "To-do 7", icon="view_list", labelText="To-do 7", isActive = false },
+                    { key = "To-do 8", value = "To-do 8", icon="view_list", labelText="To-do 8", isActive = false },
+                    { key = "To-do 9", value = "To-do 9", icon="view_list", labelText="To-do 9", isActive = false },
+                    { key = "To-do 10", value = "To-do 10", icon="view_list", labelText="To-do 10", isActive = false },
+                    { key = "LineSeparator" },
+                    { key = "To-do 11", value = "To-do 11", icon="view_list", labelText="To-do 11", isActive = false },
+                    { key = "To-do 12", value = "To-do 12", icon="view_list", labelText="To-do 12", isActive = false },
+                },
+            })
+        end
         -- add some buttons to the menu!
-
     end
     mui.newCircleButton({
         parent = muiData.parent,


### PR DESCRIPTION
## [0.1.60] - 2017-01-19
### Added
- 'hideSlidePanel()' method to hide a newSlidePanel() widget by name. This can be used in your callBacks. This keeps the slide panel in memory and hides it.
- 'showSlidePanel()' method to show a newSlidePanel() widget by name. This can be used in your callBacks. This uses the slide panel in memory and shows it.
See menu.lua for example.
