### PR TITLE
fontSize, parent, fontIsScaled added to newTileGrid and iconImage add…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.61] - 2017-01-20
+### Added
+- 'iconImage' parameter to newTileGrid() list options. Allows a tile to use an image (jpg/png) instead of icon font text.
+- 'fontIsScaled' parameter to newTileGrid(). Defaults to true.  If true scale the font to fit the width of the tile. If false let the user define the font to any size.
+- 'fontSize' parameter to newTileGrid(). Sets the overall font size for icon and text.
+- 'parent' parameter to newTileGrid().  If used it will place the newTileGrid widget into the group/parent.
+
 ## [0.1.60] - 2017-01-19
 ### Added
 - 'hideSlidePanel()' method to hide a newSlidePanel() widget by name. This can be used in your callBacks. This keeps the slide panel in memory and hides it.

--- a/tile.lua
+++ b/tile.lua
@@ -11,6 +11,9 @@ local scene = composer.newScene()
 local background = nil
 local widget = require( "widget" )
 
+-- mui
+local muiData = require( "materialui.mui-data" )
+
 -- -----------------------------------------------------------------------------------------------------------------
 -- All code outside of the listener functions will only be executed ONCE unless "composer.removeScene()" is called
 -- -----------------------------------------------------------------------------------------------------------------
@@ -40,10 +43,11 @@ function scene:create( event )
 
     sceneGroup:insert( background )
 
-    mui.init()
+    mui.init(nil, { parent=self.view })
 
     -- tile grid example
     mui.newTileGrid({
+        parent = muiData.parent,
         name = "grid_demo",
         width = mui.contentWidth,
         height = mui.contentHeight,
@@ -51,7 +55,9 @@ function scene:create( event )
         tilesPerRow = 4,
         x = 0,
         y = 0,
+        fontIsScaled = false, -- default is true for scaling font to fit tile size width or false to not scale.
         iconFont = "MaterialIcons-Regular.ttf",
+        fontSize = mui.getScaleVal(100),
         labelFont = native.systemFont,
         textColor = { 1, 1, 1 },
         labelColor = { 1, 1, 1 },
@@ -67,7 +73,7 @@ function scene:create( event )
         },
         list = {
             { key = "Home", value = "1", icon="home", labelText="Home", tileFillColor = {1,0.6,0.19,1}, tileHighlightColor = { 1, 1, 1, 1}, tileHighlightColorAlpha = 0.5, isActive = true },
-            { key = "Newsroom", value = "2", size = "2x", image="cloud-in-blue-sky855.jpg", padding=mui.getScaleVal(30), align="right", icon="wb_sunny", labelText="70 deg", tileFillColor = {0,0.34,0.6,1}, isActive = false },
+            { key = "Newsroom", value = "2", size = "2x", image="cloud-in-blue-sky855.jpg", iconImage="1484026171_02.png", padding=mui.getScaleVal(30), align="right", icon="wb_sunny", labelText="70 deg", tileFillColor = {0,0.34,0.6,1}, isActive = false },
             { key = "Location", value = "3", icon="location_searching", labelText="Location", tileFillColor = {0.36,0.81,0.42,1}, isActive = false },
             { key = "To-do", value = "4", icon="watch", tileFillColor = {0.36,0.81,0.42,1}, isActive = false },
             { key = "To-do 2", value = "5", labelText="Simple Walk", tileFillColor = {0,0.6,1,1}, isActive = false },


### PR DESCRIPTION
## [0.1.61] - 2017-01-20
### Added
- 'iconImage' parameter to newTileGrid() list options. Allows a tile to use an image (jpg/png) instead of icon font text.
- 'fontIsScaled' parameter to newTileGrid(). Defaults to true.  If true scale the font to fit the width of the tile. If false let the user define the font to any size.
- 'fontSize' parameter to newTileGrid(). Sets the overall font size for icon and text.
- 'parent' parameter to newTileGrid().  If used it will place the newTileGrid widget into the group/parent.
