### PR TITLE
added 'trimFakeTextAt' parameter to newTextField() and newTextBox() o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.63] - 2017-01-24
+### Added
+- 'trimFakeTextAt' parameter to newTextField() and newTextBox() options. Trim the text displayed when not editing to 1..Number and add ".." on end.
+
 ## [0.1.62] - 2017-01-24
 ### Added
 - 'textFieldFontSize' parameter to newTextField() options. Sets font size used in text field.

--- a/fun.lua
+++ b/fun.lua
@@ -252,6 +252,7 @@ function scene:create( event )
         height = mui.getScaleVal(200),
         x = mui.getScaleVal(240),
         y = mui.getScaleVal(750),
+        trimAtLength = 80, -- trim at 1..79 characters.
         activeColor = { 0.12, 0.67, 0.27, 1 },
         inactiveColor = { 0.4, 0.4, 0.4, 1 },
         callBack = mui.textfieldCallBack,
@@ -259,7 +260,7 @@ function scene:create( event )
         scrollView = scrollView
     })
 
-    mui.setTextBoxValue("textbox_demo1", "toys in store")
+    -- mui.setTextBoxValue("textbox_demo1", "toys in store")
 
     local textOptions =
     {

--- a/materialui/mui-textinput.lua
+++ b/materialui/mui-textinput.lua
@@ -174,6 +174,13 @@ function M.newTextField(options)
        end
     end
     
+    if options.trimFakeTextAt ~= nil then
+        local lenOfText = string.len(fadeText)
+        fadeText = string.sub(fadeText, 1, options.trimFakeTextAt)
+        if lenOfText > options.trimFakeTextAt then
+            fadeText = fadeText .. ".."
+        end
+    end
     local textOptions =
     {
         --parent = textGroup,
@@ -282,6 +289,7 @@ function M.textListener(event)
         muiData.widgetDict[name]["textfield"].isSecure = false
         M.highlightTextField(name, false)
         if event.target.callBack ~= nil then
+            local options = muiData.widgetDict[name].options
             M.updateUI(event)
             if muiData.widgetDict[name]["textfieldfake"] ~= nil then
                 local text = event.target.text
@@ -293,7 +301,16 @@ function M.textListener(event)
                     end
                 end
                 if text ~= nil and string.len(text) > 0 then
-                    muiData.widgetDict[name]["textfieldfake"].text = text
+
+                    if options.trimFakeTextAt ~= nil then
+                        muiData.widgetDict[name]["textfieldfake"].text = string.sub(text, 1, options.trimFakeTextAt)
+                        if string.len(text) > options.trimFakeTextAt then
+                            muiData.widgetDict[name]["textfieldfake"].text = muiData.widgetDict[name]["textfieldfake"].text .. ".."
+                        end
+                    else
+                        muiData.widgetDict[name]["textfieldfake"].text = text
+                    end
+                    --muiData.widgetDict[name]["textfieldfake"].text = text
                 else
                     muiData.widgetDict[name]["textfieldfake"].text = muiData.widgetDict[name]["textfield"].placeholder
                 end
@@ -420,10 +437,18 @@ function M.newTextBox(options)
     muiData.widgetDict[options.name]["textfield"].text = options.text
     muiData.widgetDict[options.name]["textfield"]:setTextColor( unpack(muiData.widgetDict[options.name]["textlabel"].inactiveColor) )
 
+    local fadeText = options.text
+    if options.trimFakeTextAt ~= nil then
+        local lenOfText = string.len(fadeText)
+        fadeText = string.sub(fadeText, 1, options.trimFakeTextAt)
+        if lenOfText > options.trimFakeTextAt then
+            fadeText = fadeText .. ".."
+        end
+    end
     local textOptions =
     {
         --parent = textGroup,
-        text = options.text,
+        text = fadeText,
         x = 0,
         y = 0,
         width = options.width,
@@ -455,15 +480,41 @@ end
 
 function M.setTextFieldValue(widgetName, value)
     if widgetName ~= nil then
+        local options = muiData.widgetDict[widgetName].options
         muiData.widgetDict[widgetName]["textfield"].text = value
-        muiData.widgetDict[widgetName]["textfieldfake"].text = value
+        if value ~= nil then
+            if options.trimFakeTextAt ~= nil then
+                value = string.sub(value, 1, options.trimFakeTextAt)
+                if string.len(text) > options.trimFakeTextAt then
+                    value = value .. ".."
+                end
+                muiData.widgetDict[widgetName]["textfieldfake"].text = value
+            else
+                muiData.widgetDict[widgetName]["textfieldfake"].text = value
+            end
+        else
+            muiData.widgetDict[widgetName]["textfieldfake"].text = value
+        end
     end
 end
 
 function M.setTextBoxValue(widgetName, value)
     if widgetName ~= nil then
+        local options = muiData.widgetDict[widgetName].options
         muiData.widgetDict[widgetName]["textfield"].text = value
-        muiData.widgetDict[widgetName]["textfieldfake"].text = value
+        if value ~= nil then
+            if options.trimFakeTextAt ~= nil then
+                value = string.sub(value, 1, options.trimFakeTextAt)
+                if string.len(text) > options.trimFakeTextAt then
+                    value = value .. ".."
+                end
+                muiData.widgetDict[widgetName]["textfieldfake"].text = value
+            else
+                muiData.widgetDict[widgetName]["textfieldfake"].text = value
+            end
+        else
+            muiData.widgetDict[widgetName]["textfieldfake"].text = value
+        end
     end
 end
 

--- a/menu.lua
+++ b/menu.lua
@@ -565,6 +565,7 @@ function scene:create( event )
         height = mui.getScaleVal(46),
         x = mui.getScaleVal(240),
         y = mui.getScaleVal(330),
+        trimAtLength = 30,
         activeColor = { 0, 0, 0, 1 },
         inactiveColor = { 0.5, 0.5, 0.5, 1 },
         callBack = mui.textfieldCallBack


### PR DESCRIPTION
## [0.1.63] - 2017-01-24
### Added
- 'trimFakeTextAt' parameter to newTextField() and newTextBox() options. Trim the text displayed when not editing to 1..Number and add ".." on end.
