### PR TITLE
newNavbar() added method support for getWidgetBaseObject() and parent…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.76] - 2017-02-20
+### Changes
+- newNavbar() added method support for getWidgetBaseObject() and 'parent' object support in options for newNavbar().
+
 ## [0.1.75] - 2017-02-20
 ### Changes
 - Fixed issue with newSlidePanel() labelColor, labelColorOff and iconColor and iconColorOff not setting correctly when selected and de-selected.

--- a/materialui/mui-base.lua
+++ b/materialui/mui-base.lua
@@ -304,6 +304,8 @@ function M.getWidgetBaseObject(name)
                widgetData = muiData.widgetDict[widget]["mygroup"]
             elseif widgetType == "TimePicker" then
                widgetData = muiData.widgetDict[widget]["mygroup"]
+            elseif widgetType == "Navbar" or widgetType == "NavBar" then
+               widgetData = muiData.widgetDict[widget]["container"]
             elseif widgetType == "ProgressArc" then
                widgetData = muiData.widgetDict[widget]["mygroup"]
             elseif widgetType == "ProgressBar" then
@@ -349,7 +351,7 @@ function M.getWidgetProperty( widgetName, propertyName )
     widgetData = M.getImageProperty( widgetName, propertyName )
   elseif muiData.widgetDict[widgetName]["type"] == "ImageRect" then
     widgetData = M.getImageRectProperty( widgetName, propertyName )
-  elseif muiData.widgetDict[widgetName]["type"] == "NavBar" then
+  elseif muiData.widgetDict[widgetName]["type"] == "Navbar" or muiData.widgetDict[widgetName]["type"] == "NavBar" then
     widgetData = M.getNavBarProperty( widgetName, propertyName )
   elseif muiData.widgetDict[widgetName]["type"] == "Popover" then
     widgetData = M.getPopoverProperty( widgetName, propertyName )

--- a/materialui/mui-navbar.lua
+++ b/materialui/mui-navbar.lua
@@ -105,6 +105,11 @@ function M.newNavbar( options )
         }
     )
 
+    if options.parent ~= nil then
+        muiData.widgetDict[options.name]["parent"] = options.parent
+        muiData.widgetDict[options.name]["parent"]:insert( muiData.widgetDict[options.name]["container"] )
+    end   
+
     local newX = muiData.widgetDict[options.name]["container"].contentWidth * 0.5
     local newY = muiData.widgetDict[options.name]["container"].contentHeight * 0.5
 


### PR DESCRIPTION
## [0.1.76] - 2017-02-20
### Changes
- newNavbar() added method support for getWidgetBaseObject() and 'parent' object support in options for newNavbar().
