### PR TITLE
Big update. A number of issues resolved.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.80] - 2017-03-16
+### Changes
+- getOrientation() gets the current orientation as locked. mui only supports Portrait or Landscape. It cannot be both at this time.
+- setSceneToSwitchToAfterDestroy([name]) to override what scene to go to after mui.destroy() executes.
+- 'sceneTransitionAnimation' parameter for scene transitions. Is boolean and if "true" (default) it will animate before going to next scene.  If "false" it will not animate and go to next scene immediately.  See menu.lua for an example.
+- muiData.parent variable is replaced with mui.getParent() method. muiData.parent is still supported but will be deprecated in the future.
+
+### Fixes
+- Fixed getScaleVal() and orientation issues. This was causing issues on device and in emulator. Issues like crashing since the device could be rotated, flipped etc messing up the calculations. Again use a locked position for now in "mui" and go with Portrait or Landscape. These in any "portait" or "landscape" orientation, but not both "portrait" and "landscape"
+- Using a new animation for switching between scenes. It's smoother.
+- Re-did the order of mui.destroy() and now it will cancel all "transitions" before proceeding to destroy.
+
+
 ## [0.1.77] - 2017-02-23
 ### Changes
 - newSlidePanel() supports swipe gestures to open and close the menu.

--- a/build.settings
+++ b/build.settings
@@ -12,7 +12,7 @@ settings =
 		-- portrait, portraitUpsideDown, landscapeLeft, landscapeRight
 
 		default = "landscapeRight",
-		supported = { "landscapeRight", }
+		supported = { "landscapeRight", "landscapeLeft", }
 	},
 	
 	excludeFiles =

--- a/config.lua
+++ b/config.lua
@@ -28,7 +28,7 @@ application =
 		height = 1920, 
 		--]]--
 
-		scale = "letterBox",
+		-- scale = "letterBox",
 		fps = 30,
 		
 		--[[

--- a/fun.lua
+++ b/fun.lua
@@ -8,7 +8,6 @@
 local composer = require( "composer" )
 local widget = require( "widget" )
 
--- mui
 local mui = require( "materialui.mui" )
 
 local scene = composer.newScene()
@@ -20,7 +19,6 @@ local screenW, screenH, halfW = display.contentWidth, display.contentHeight, dis
 
 local background = nil
 local scrollView = nil
-local infoText = nil
 
 local function destroyDemoText( demoText )
     print("destroyDemoText called")
@@ -45,8 +43,10 @@ function scene:create( event )
 	background.anchorX = 0
 	background.anchorY = 0
 	background:setFillColor( unpack(colorFill) )
+    sceneGroup:insert( background )
 
     mui.init()
+
     mui.newRoundedRectButton({
         scrollView = scrollView,
         name = "goBack",
@@ -63,9 +63,10 @@ function scene:create( event )
         iconFontColor = { 1, 1, 1, 1 },
         -- iconImage = "1484026171_02.png",
         callBack = mui.actionSwitchScene,
-        callBackData = { 
+        callBackData = {
             sceneDestination = "menu",
-            sceneTransitionColor = { 0, 0.73, 1 }
+            sceneTransitionColor = { 0, 0.73, 1 },
+            sceneTransitionAnimation = true
         } -- scene menu.lua
     })
 
@@ -169,20 +170,20 @@ function scene:create( event )
     })
     --]]--
 
-	-- Create the widget
+    -- Create the widget
     ---[[--
-	local scrollWidth = display.contentWidth * 0.5
-	scrollView = widget.newScrollView(
-	    {
-	        top = mui.getScaleVal(30),
-	        left = (display.contentWidth - scrollWidth),
-	        width = scrollWidth,
-	        height = mui.getScaleVal(450),
-	        scrollWidth = scrollWidth,
-	        scrollHeight = (display.contentHeight * 2),
-	        listener = scrollAListener
-	    }
-	)
+    local scrollWidth = display.contentWidth * 0.5
+    scrollView = widget.newScrollView(
+        {
+            top = mui.getScaleVal(30),
+            left = (display.contentWidth - scrollWidth),
+            width = scrollWidth,
+            height = mui.getScaleVal(450),
+            scrollWidth = scrollWidth,
+            scrollHeight = (display.contentHeight * 2),
+            listener = scrollAListener
+        }
+    )
 
     mui.newTextField({
         name = "textfield_demo2",
@@ -426,8 +427,6 @@ function scene:create( event )
         padding = mui.getScaleVal(20),
         align = "right",  -- left | right supported
     })
-
-	sceneGroup:insert( background )
 end
 
 --
@@ -475,6 +474,8 @@ function scene:show( event )
 		-- INSERT code here to make the scene come alive
 		-- e.g. start timers, begin animation, play audio, etc.
 		--physics.start()
+        -- mui.actionSwitchScene({callBackData={sceneDestination="menu"}})
+
 	end
 end
 
@@ -505,11 +506,10 @@ function scene:destroy( event )
 
     mui.destroy()
 
-    scrollView:removeSelf()
-    scrollView = nil
-
-    infoText:removeSelf()
-    infoText = nil
+    if scrollView ~= nil then
+        scrollView:removeSelf()
+        scrollView = nil
+    end
 
     if background ~= nil then
         background:removeSelf()

--- a/materialui/mui-tableview.lua
+++ b/materialui/mui-tableview.lua
@@ -41,6 +41,7 @@ local mathMod = math.fmod
 local mathABS = math.abs
 
 local M = muiData.M -- {} -- for module array/table
+local MySceneName = nil
 
 function M.createTableView( options )
     M.newTableView( options )
@@ -86,10 +87,11 @@ function M.newTableView( options )
         options.rowAnimation = true
     end
 
-    muiData.tableCircle = display.newCircle( 0, 0, M.getScaleVal(20 * 2.5) )
-    muiData.tableCircle:setFillColor( unpack(options.circleColor) )
-    muiData.tableCircle.isVisible = false
-    muiData.tableCircle.alpha = 0.55
+    MySceneName = M.getCurrentScene()
+    muiData.sceneData[MySceneName].tableCircle = display.newCircle( 0, 0, M.getScaleVal(20 * 2.5) )
+    muiData.sceneData[MySceneName].tableCircle:setFillColor( unpack(options.circleColor) )
+    muiData.sceneData[MySceneName].tableCircle.isVisible = false
+    muiData.sceneData[MySceneName].tableCircle.alpha = 0.55
     muiData.tableRow = nil
 
     -- Create the widget
@@ -448,15 +450,16 @@ function M.onRowTouch( event )
         end
 
         if rowAnimation == true then
-            muiData.tableCircle:toFront()
+            MySceneName = M.getCurrentScene()
+            muiData.sceneData[MySceneName].tableCircle:toFront()
 
-            muiData.tableCircle.alpha = 0.55
+            muiData.sceneData[MySceneName].tableCircle.alpha = 0.55
             if row.miscEvent == nil then return end
-            muiData.tableCircle.x = row.miscEvent.x
-            muiData.tableCircle.y = row.miscEvent.y
+            muiData.sceneData[MySceneName].tableCircle.x = row.miscEvent.x
+            muiData.sceneData[MySceneName].tableCircle.y = row.miscEvent.y
             local scaleFactor = 0.1 --2.5
-            muiData.tableCircle.isVisible = true
-            muiData.tableCircle.myCircleTrans = transition.from( muiData.tableCircle, { time=300,alpha=0.2, xScale=scaleFactor, yScale=scaleFactor, transition=easing.inOutCirc, onComplete=M.subtleRadius } )
+            muiData.sceneData[MySceneName].tableCircle.isVisible = true
+            muiData.sceneData[MySceneName].tableCircle.myCircleTrans = transition.from( muiData.sceneData[MySceneName].tableCircle, { time=300,alpha=0.2, xScale=scaleFactor, yScale=scaleFactor, transition=easing.inOutCirc, onComplete=M.subtleRadius } )
             row.myGlowTrans = transition.to( row, { time=300,delay=150,alpha=0.4, transition=easing.outCirc, onComplete=M.subtleGlowRect } )
         end
 

--- a/menu.lua
+++ b/menu.lua
@@ -8,6 +8,10 @@ local composer = require( "composer" )
 local mui = require( "materialui.mui" )
 
 local scene = composer.newScene()
+
+-- forward declarations and other locals
+local screenW, screenH, halfW = display.contentWidth, display.contentHeight, display.contentWidth*0.5
+
 local background = nil
 local widget = require( "widget" )
 
@@ -117,7 +121,7 @@ function scene:create( event )
     -- below is a rounded button with static image with two states (off/on)
     -- tap or click and "hold" to see shadow and release to see it fade to original image
     mui.newRoundedRectButton({
-        parent = muiData.parent,
+        parent = mui.getParent(),
         name = "newDialog",
         text = "Open Dialog",
         width = mui.getScaleVal(300),
@@ -157,7 +161,7 @@ function scene:create( event )
     })
 
     mui.newRectButton({
-        parent = muiData.parent,
+        parent = mui.getParent(),
         name = "switchSceneButton",
         text = "Go Scene",
         width = mui.getScaleVal(250),
@@ -173,9 +177,10 @@ function scene:create( event )
         --iconImage = "1484026171_02.png",
         touchpoint = true,
         callBack = mui.actionSwitchScene,
-        callBackData = { 
+        callBackData = {
             sceneDestination = "fun",
-            sceneTransitionColor = { 0, 0.73, 1 }
+            sceneTransitionColor = { 0, 0.73, 1 },
+            sceneTransitionAnimation = true
         } -- scene fun.lua
     })
 
@@ -191,7 +196,7 @@ function scene:create( event )
     end
 
     mui.newIconButton({
-        parent = muiData.parent,
+        parent = mui.getParent(),
         name = "plus",
         text = "help",
         width = mui.getScaleVal(50),
@@ -212,7 +217,7 @@ function scene:create( event )
     -- date picker example
     local showDatePicker = function(event)
         mui.newDatePicker({
-            parent = muiData.parent,
+            parent = mui.getParent(),
             name = "datepicker-demo",
             font = native.systemFont,
             fontSize = mui.getScaleVal(26),
@@ -240,7 +245,7 @@ function scene:create( event )
         })
     end
     mui.newCircleButton({
-        parent = muiData.parent,
+        parent = mui.getParent(),
         name = "alice-button",
         text = "date_range",
         radius = mui.getScaleVal(46),
@@ -256,7 +261,7 @@ function scene:create( event )
     -- time picker example
     local showTimePicker = function(event)
         mui.newTimePicker({
-            parent = muiData.parent,
+            parent = mui.getParent(),
             name = "timepicker-demo",
             font = native.systemFont,
             width = mui.getScaleVal(400),
@@ -281,7 +286,7 @@ function scene:create( event )
         })
     end
     mui.newCircleButton({
-        parent = muiData.parent,
+        parent = mui.getParent(),
         name = "bueler-button",
         text = "access_time",
         radius = mui.getScaleVal(46),
@@ -310,7 +315,7 @@ function scene:create( event )
         else
             print("slidePanel is new")
             mui.newSlidePanel({
-                parent = muiData.parent,
+                parent = mui.getParent(),
                 name = "slidepanel-demo",
                 title = "MUI Demo", -- leave blank for no panel title text
                 titleAlign = "center",
@@ -360,7 +365,7 @@ function scene:create( event )
         -- add some buttons to the menu!
     end
     mui.newCircleButton({
-        parent = muiData.parent,
+        parent = mui.getParent(),
         name = "slidepanel-button",
         text = "menu",
         radius = mui.getScaleVal(46),
@@ -379,7 +384,7 @@ function scene:create( event )
         local button = mui.getWidgetBaseObject( "vertical-menu-button" )
 
         mui.newPopover({
-            parent = muiData.parent,
+            parent = mui.getParent(),
             name = "popovermenu_demo1",
             font = native.systemFont,
             textColor = { 0.4, 0.4, 0.4 },
@@ -406,7 +411,7 @@ function scene:create( event )
     end
 
     mui.newIconButton({
-        parent = muiData.parent,
+        parent = mui.getParent(),
         name = "vertical-menu-button",
         text = "more_vert",
         width = mui.getScaleVal(46),
@@ -424,7 +429,7 @@ function scene:create( event )
     -- SnackBar example
     local function showSnackBar( ... )
         mui.newSnackBar({
-            parent = muiData.parent,
+            parent = mui.getParent(),
             name = "snackbar_demo1",
             text = "Updated Demo",
             radius = mui.getScaleVal(10),
@@ -446,7 +451,7 @@ function scene:create( event )
     end
 
     mui.newIconButton({
-        parent = muiData.parent,
+        parent = mui.getParent(),
         name = "snackbar_button",
         text = "local_cafe",
         width = mui.getScaleVal(46),
@@ -463,7 +468,7 @@ function scene:create( event )
 
     -- tile widget example
     mui.newCircleButton({
-        parent = muiData.parent,
+        parent = mui.getParent(),
         name = "tile-button",
         text = "view_list",
         radius = mui.getScaleVal(46),
@@ -482,7 +487,7 @@ function scene:create( event )
 
     -- checkbox example
     mui.newCheckBox({
-        parent = muiData.parent,
+        parent = mui.getParent(),
         name = "check",
         text = "check_box_outline_blank",
         width = mui.getScaleVal(50),
@@ -499,7 +504,7 @@ function scene:create( event )
 
     -- toggle switch example
     mui.newToggleSwitch({
-        parent = muiData.parent,
+        parent = mui.getParent(),
         name = "switch_demo",
         size = mui.getScaleVal(55),
         x = mui.getScaleVal(360),
@@ -515,7 +520,7 @@ function scene:create( event )
 
     -- radio button group example
     mui.newRadioGroup({
-        parent = muiData.parent,
+        parent = mui.getParent(),
         name = "radio_demo",
         width = mui.getScaleVal(30),
         height = mui.getScaleVal(30),
@@ -535,7 +540,7 @@ function scene:create( event )
 
     ---[[
     mui.newTableView({
-        parent = muiData.parent,
+        parent = mui.getParent(),
         name = "tableview_demo",
         width = mui.getScaleVal(300),
         height = mui.getScaleVal(300),
@@ -592,7 +597,7 @@ function scene:create( event )
     --]]--
 
     mui.newTextField({
-        parent = muiData.parent,
+        parent = mui.getParent(),
         name = "textfield_demo",
         labelText = "Subject",
         text = "Hello, world!",
@@ -608,7 +613,7 @@ function scene:create( event )
     })
 
     mui.newTextField({
-        parent = muiData.parent,
+        parent = mui.getParent(),
         name = "textfield_demo_with_placeholder",
         labelText = "Test Placeholder",
         placeholder = "You see me when text is empty",
@@ -625,7 +630,7 @@ function scene:create( event )
 
     -- create and animate the intial value (1% is always required due to scaling method)
     mui.newProgressBar({
-        parent = muiData.parent,
+        parent = mui.getParent(),
         name = "progressbar_demo",
         width = mui.getScaleVal(290),
         height = mui.getScaleVal(8),
@@ -657,7 +662,7 @@ function scene:create( event )
     -- on bottom and stay on top of other widgets.
     local buttonHeight = mui.getScaleVal(70)
     mui.newToolbar({
-        parent = muiData.parent,
+        parent = mui.getParent(),
         name = "toolbar_demo",
         --width = mui.getScaleVal(500), -- defaults to display.contentWidth
         height = mui.getScaleVal(70),
@@ -700,7 +705,7 @@ function scene:show( event )
         -- Called when the scene is now on screen
         -- Insert code here to make the scene come alive
         -- Example: start timers, begin animation, play audio, etc.
-
+        -- mui.actionSwitchScene({callBackData={sceneDestination="fun"}})
     end
 end
 
@@ -731,6 +736,7 @@ function scene:destroy( event )
     -- Insert code here to clean up the scene
     -- Example: remove display objects, save state, etc.
     mui.destroy()
+
     if background ~= nil then
         background:removeSelf()
         background = nil

--- a/tile.lua
+++ b/tile.lua
@@ -47,7 +47,7 @@ function scene:create( event )
 
     -- tile grid example
     mui.newTileGrid({
-        parent = muiData.parent,
+        parent = mui.getParent(),
         name = "grid_demo",
         width = mui.contentWidth,
         height = mui.contentHeight,


### PR DESCRIPTION
## [0.1.80] - 2017-03-16
### Changes
- getOrientation() gets the current orientation as locked. mui only supports Portrait or Landscape. It cannot be both at this time.
- setSceneToSwitchToAfterDestroy([name]) to override what scene to go to after mui.destroy() executes.
- 'sceneTransitionAnimation' parameter for scene transitions. Is boolean and if "true" (default) it will animate before going to next scene.  If "false" it will not animate and go to next scene immediately.  See menu.lua for an example.
- muiData.parent variable is replaced with mui.getParent() method. muiData.parent is still supported but will be deprecated in the future.

### Fixes
- Fixed getScaleVal() and orientation issues. This was causing issues on device and in emulator. Issues like crashing since the device could be rotated, flipped etc messing up the calculations. Again use a locked position for now in "mui" and go with Portrait or Landscape. These in any "portait" or "landscape" orientation, but not both "portrait" and "landscape"
- Using a new animation for switching between scenes. It's smoother.
- Re-did the order of mui.destroy() and now it will cancel all "transitions" before proceeding to destroy.
