### PR TITLE
added helper methods for newSelect(): setSelectorList(), setSelectorV…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.84] - 2017-03-17
+### Changes
+- setSelectorList() method added to set the named drop-down selector with the contents of a list. This makes it easier to dynamically update the list after declaration.  See commented out example in fun.lua.
+- setSelectorValue() method added to set the named drop-down selector's current text and value content.
+
+### Fixes
+- Fixed newTextBox() contents overflowing out of defined area. The text is now in a container and the text is always around to the top (shows first line of content on down).
+
 ## [0.1.80] - 2017-03-16
 ### Changes
 - getOrientation() gets the current orientation as locked. mui only supports Portrait or Landscape. It cannot be both at this time.

--- a/fun.lua
+++ b/fun.lua
@@ -140,6 +140,16 @@ function scene:create( event )
         },
     })
 
+    ---[[--
+    local newlist = {}
+    newlist = {
+        { key = "Row1", text = "Dog", value = "Puggle", isCategory = false},
+        { key = "Row2", text = "Cat", value = "Tabby", isCategory = false },
+        { key = "Row3", text = "Dinosaur", value = "Raptor", isCategory = false },
+    }
+    mui.setSelectorList("selector_demo1", newlist)
+    --]]--
+
     -- horizontal slider (vertical in development)
     ---[[--
     mui.newSlider({

--- a/materialui/mui-base.lua
+++ b/materialui/mui-base.lua
@@ -107,7 +107,7 @@ function M.init_base(options)
   -- utf8 support required for Android API < 23 (to be safe)
   muiData.utf8 = utf8v1
   muiData.utf8Assist = false
-  if muiData.androidApiLevel ~= nil and tonumber(muiData.androidApiLevel) < 23 then
+  if (muiData.androidApiLevel ~= nil and tonumber(muiData.androidApiLevel) < 23) or string.find(muiData.platform, "win") then
     muiData.utf8Assist = true
     muiData.materialFont = "MaterialIcons-Regular.otf"
     muiData.materialFontCodePoints = materialFontCodePoints

--- a/materialui/mui-select.lua
+++ b/materialui/mui-select.lua
@@ -102,6 +102,11 @@ function M.newSelect(options)
         options.strokeColor = { 0.4, 0.4, 0.4, 1 }
     end
 
+    muiData.widgetDict[options.name].list = nil
+    if options.list ~= nil then
+        muiData.widgetDict[options.name].list = options.list
+    end
+
     muiData.widgetDict[options.name]["rect"] = display.newRect( 0, 0, options.width, options.height )
     muiData.widgetDict[options.name]["rect"]:setFillColor( unpack( options.fieldBackgroundColor ) )
     muiData.widgetDict[options.name]["container"]:insert( muiData.widgetDict[options.name]["rect"] )
@@ -200,6 +205,29 @@ function M.getSelectorProperty(widgetName, propertyName)
     return data
 end
 
+function M.setSelectorList(widgetName, list)
+    if widgetName == nil or list == nil then return end
+    if muiData.widgetDict[widgetName]["type"] == "Selector" then
+         muiData.widgetDict[widgetName].list = list
+         local text = ""
+         local value = ""
+         for k, v in pairs(list) do
+             text = v.text
+             value = v.value
+             break
+         end
+         M.setSelectorValue(widgetName, text, value)
+    end
+end
+
+function M.setSelectorValue(widgetName, text, value)
+    if widgetName == nil or text == nil or value == nil then return end
+    if muiData.widgetDict[widgetName]["type"] == "Selector" then
+         muiData.widgetDict[widgetName]["selectorfieldfake"].text = text
+         muiData.widgetDict[widgetName]["value"] = value
+    end
+end
+
 function M.revealTableViewForSelector(name, options)
     -- table view to hold pick list keyboard_arrow_down
     muiData.widgetDict[options.name]["mygroup"] = display.newGroup() -- options.width+4, options.height + options.listHeight)
@@ -235,7 +263,7 @@ function M.revealTableViewForSelector(name, options)
         categoryColor = options.categoryColor,
         categoryLineColor = options.categoryLineColor,
         touchpointColor = options.touchpointColor,
-        list = options.list
+        list = muiData.widgetDict[options.name].list
     })
 
     muiData.widgetDict[options.name]["rect2"] = display.newRect( options.width * 0.5, (options.listHeight * 0.45) + options.height, options.width, options.listHeight + (options.height * 0.5))


### PR DESCRIPTION
## [0.1.84] - 2017-03-17
### Changes
- setSelectorList() method added to set the named drop-down selector with the contents of a list. This makes it easier to dynamically update the list after declaration.  See commented out example in fun.lua.
- setSelectorValue() method added to set the named drop-down selector's current text and value content.

### Fixes
- Fixed newTextBox() contents overflowing out of defined area. The text is now in a container and the text is always around to the top (shows first line of content on down).
