### PR TITLE
disabled 'number' input due to mobile iOS has no way to 'finish' entr…

### DIFF
--- a/materialui/mui-textinput.lua
+++ b/materialui/mui-textinput.lua
@@ -70,6 +70,8 @@ function M.newTextField(options)
 
     if options.inputType == nil then
         options.inputType = "default"
+    elseif options.inputType == "number" then
+        options.inputType = "default" -- due to numpad on mobile not having a way to "enter" or "finish" input
     end
 
     if options.fillColor == nil then


### PR DESCRIPTION
*Changes*

- Temporarily disabled 'number' input text due to mobile iOS has no way to 'finish' entry. Will re-enable soon with custom done button