### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.96] - 2017-05-05
+### Fixes
+- newTableView() - Tapping repeatly did not register an event. This is fixed now. Which was an issue on all devices and simulator.
+
 ## [0.1.93] - 2017-04-23
 ### Fixes
 - newSlidePanel() - Slide panel would not always slide out fully. This is fixed now.

--- a/materialui/mui-tableview.lua
+++ b/materialui/mui-tableview.lua
@@ -458,7 +458,7 @@ end
 function M.onRowTouch( event )
     local phase = event.phase
     local row = event.row
- 
+
     if muiData.dialogInUse == true then
         if muiData.dialogName == nil then return end
         if string.find(row.params.name, muiData.dialogName) == nil then
@@ -466,7 +466,7 @@ function M.onRowTouch( event )
         end
     end
 
-    if "press" == phase and muiData.touching == false then
+    if (phase == "tap" or "press" == phase) and muiData.touching == false then
         muiData.touching = true
         local skipNameToRemove = nil
         if string.find(string.lower(row.params.basename), "-list") then
@@ -475,7 +475,9 @@ function M.onRowTouch( event )
         M.updateUI(event, skipNameToRemove)
         --M.debug( "Touched row:", event.target.id )
         --M.debug( "Touched row:", event.target.index )
-    elseif "release" == phase then
+    end
+
+    if ("release" == phase or "tap" == phase) then
         local row = event.row
 
         local rowAnimation = true


### PR DESCRIPTION
## [0.1.96] - 2017-05-05
### Fixes
- newTableView() - Tapping repeatly did not register an event. This is fixed now. Which was an issue on all devices and simulator.  Fixes Dropdown buttons (select drop down) and other areas using tables.
