### PR TITLE
Now after choosing a drop down item the 'text' for the item is shown.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.97] - 2017-06-12
+### Fixes
+- newSelect() - Fixed issue where value was being used in the 'selected' text instead of the text for the button.  Now after choosing a drop down item the 'text' for the item is shown.
+
 ## [0.1.96] - 2017-05-05
 ### Fixes
 - newTableView() - Tapping repeatly did not register an event. This is fixed now. Which was an issue on all devices and simulator.

--- a/materialui/mui-select.lua
+++ b/materialui/mui-select.lua
@@ -374,7 +374,9 @@ function M.onRowTouchSelector(event)
     if event.row.miscEvent ~= nil and event.row.miscEvent.name ~= nil then
         local parentName = string.gsub(event.row.miscEvent.name, "-List", "")
 
-        muiData.widgetDict[parentName]["selectorfieldfake"].text = muiTargetValue
+        if muiTargetIndex ~= nil then
+            muiData.widgetDict[parentName]["selectorfieldfake"].text =  muiData.widgetDict[parentName].list[muiTargetIndex].text -- was muiTargetValue
+        end
         muiData.widgetDict[parentName]["value"] = muiTargetValue
         timer.performWithDelay(500, function() M.finishSelector(parentName) end, 1)
     else


### PR DESCRIPTION
## [0.1.97] - 2017-06-12
### Fixes
- newSelect() - Fixed issue where value was being used in the 'selected' text instead of the text for the button.  Now after choosing a drop down item the 'text' for the item is shown.
