### PR TITLE
newDialog: Making overlay cover whole screen always

### DIFF
--- a/materialui/mui-dialog.lua
+++ b/materialui/mui-dialog.lua
@@ -97,7 +97,7 @@ function M.newDialog(options)
 
     -- place on main display
     muiData.widgetDict[options.name] = {}
-    muiData.widgetDict[options.name]["rectbackdrop"] = display.newRect( muiData.contentWidth * 0.5, muiData.contentHeight * 0.5, muiData.contentWidth, muiData.contentHeight)
+    muiData.widgetDict[options.name]["rectbackdrop"] = display.newRect( 0, 0, display.pixelWidth, display.pixelHeight )
     muiData.widgetDict[options.name]["rectbackdrop"].strokeWidth = 0
     muiData.widgetDict[options.name]["rectbackdrop"]:setFillColor( unpack( {0.4, 0.4, 0.4, 0.3} ) )
     muiData.widgetDict[options.name]["rectbackdrop"].isVisible = true


### PR DESCRIPTION
The overlay for the dialog box was not covering the whole screen on letterbox.

This fix seems to work on all devices/resolutions... but I'm not a corona expert. Please test before merge.