### PR TITLE
Bringing panel to front

### DIFF
--- a/materialui/mui-slidepanel.lua
+++ b/materialui/mui-slidepanel.lua
@@ -663,8 +663,10 @@ function M.showSlidePanel( widgetName, slideOut )
             transition.fadeIn(muiData.widgetDict[widgetName]["rectbackdrop"],{time=300})
             muiData.widgetDict[widgetName]["rectclick"].isVisible = true
             muiData.widgetDict[widgetName]["rectbackdrop"].isVisible = true
+			muiData.widgetDict[widgetName]["scrollview"]:toFront()
         else
             muiData.widgetDict[widgetName].isVisible = true
+			muiData.widgetDict[widgetName]["scrollview"]:toFront()
             --transition.fadeIn(muiData.widgetDict[widgetName]["rectclick"],{time=0})
             --transition.fadeIn(muiData.widgetDict[widgetName]["rectbackdrop"],{time=0})
         end


### PR DESCRIPTION
If your scene has objects that were added after the slide panel was added, they will be shown on top of the panel. This commit ensures that the slide panel is over any other object on screen.

Should've probably put this out of the `if/else` statement... :/

meh
